### PR TITLE
Ensure Google Sheet headers include new aligner fields

### DIFF
--- a/lab_pg.py
+++ b/lab_pg.py
@@ -93,7 +93,12 @@ def get_worksheet():
         ws = ss.worksheet(ws_name)
     except gspread.WorksheetNotFound:
         ws = ss.add_worksheet(title=ws_name, rows="1000", cols=str(len(COLUMNS)))
-        ws.update([COLUMNS])
+        ws.update("A1", [COLUMNS])
+    else:
+        # Mantener sincronizada la fila de encabezados con los campos definidos.
+        current_headers = ws.row_values(1)
+        if current_headers[: len(COLUMNS)] != COLUMNS:
+            ws.update("A1", [COLUMNS])
     return ws
 
 @st.cache_data(ttl=30)
@@ -158,8 +163,8 @@ with tab1:
             "Status": in_status,
             "Status_NEMO": in_status_nemo,
             "Tipo_alineador": in_tipo_alineador,
-            "Fecha_recepcion": in_fecha_recepcion.isoformat(),
-            "Dias_entrega": int(in_dias_entrega),
+            "Fecha_recepcion": in_fecha_recepcion.strftime("%Y-%m-%d"),
+            "Dias_entrega": str(int(in_dias_entrega)),
             "Comentarios": in_comentarios,
             "Notas": in_notas,
             "Ultima_Modificacion": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),


### PR DESCRIPTION
## Summary
- ensure the Google Sheet header row matches the expanded COLUMNS definition when the worksheet already exists
- format the new reception date and delivery day inputs as strings before appending rows to keep storage consistent

## Testing
- python -m py_compile lab_pg.py

------
https://chatgpt.com/codex/tasks/task_e_68d1a83d876c8326a68d09e8e57b164b