### PR TITLE
Improve IPR radio labels

### DIFF
--- a/lab_pg.py
+++ b/lab_pg.py
@@ -517,6 +517,12 @@ with tab_sud:
             "Solo impresión": "🖨️",
         }
 
+        ipr_option_labels = {
+            "x": "X",
+            "-": "Sin IPR (-)",
+        }
+        ipr_options = list(ipr_option_labels.keys())
+
         def _parse_date(value):
             try:
                 return datetime.strptime(value, "%Y-%m-%d").date()
@@ -800,10 +806,16 @@ with tab_sud:
 
                 ipr_default = row.get("IPR", "-") if row.get("IPR") else "-"
                 ipr_key = f"{form_key}_ipr"
+                ipr_index = (
+                    ipr_options.index(ipr_default)
+                    if ipr_default in ipr_options
+                    else 0
+                )
                 st.radio(
                     "IPR",
-                    options=["x", "-"],
-                    index=0 if ipr_default == "x" else 1,
+                    options=ipr_options,
+                    index=ipr_index,
+                    format_func=lambda value: ipr_option_labels.get(value, value),
                     key=ipr_key,
                     on_change=save_field,
                     args=("IPR",),


### PR DESCRIPTION
## Summary
- add a label mapping for SUD IPR options so the dash value is shown with a descriptive caption
- update the IPR radio button to use the mapping via `format_func` while keeping storage values unchanged

## Testing
- python -m compileall lab_pg.py

------
https://chatgpt.com/codex/tasks/task_e_68d3282f41548326ac494138638c7d16