### PR TITLE
Fix tab state initialization for Streamlit tabs

### DIFF
--- a/lab_pg.py
+++ b/lab_pg.py
@@ -60,6 +60,9 @@ TAB_LABELS = ["➕ Nuevo Proceso", "SUD", "📋 Consulta"]
 SUD_TAB_LABEL = TAB_LABELS[1]
 TABS_STATE_KEY = "main_tabs"
 SUD_EXPANDERS_STATE_KEY = "sud_expanders_state"
+DEFAULT_TAB_INDEX = 0
+SUD_TAB_INDEX = TAB_LABELS.index(SUD_TAB_LABEL)
+_TAB_LABEL_TO_INDEX = {label: idx for idx, label in enumerate(TAB_LABELS)}
 
 _STATUS_LABELS = [
     "1. Revisión de scan",
@@ -234,8 +237,12 @@ def _resolve_option_data(
 
 
 def _ensure_ui_state_defaults() -> None:
-    if TABS_STATE_KEY not in st.session_state:
-        st.session_state[TABS_STATE_KEY] = TAB_LABELS[0]
+    current_tab = st.session_state.get(TABS_STATE_KEY, DEFAULT_TAB_INDEX)
+    if isinstance(current_tab, str):
+        current_tab = _TAB_LABEL_TO_INDEX.get(current_tab, DEFAULT_TAB_INDEX)
+    elif not isinstance(current_tab, int):
+        current_tab = DEFAULT_TAB_INDEX
+    st.session_state[TABS_STATE_KEY] = current_tab
     if SUD_EXPANDERS_STATE_KEY not in st.session_state:
         st.session_state[SUD_EXPANDERS_STATE_KEY] = {}
 
@@ -253,7 +260,7 @@ def _normalize_expander_key(row_index) -> str | None:
 
 
 def _focus_sud_tab(row_index=None) -> None:
-    st.session_state[TABS_STATE_KEY] = SUD_TAB_LABEL
+    st.session_state[TABS_STATE_KEY] = SUD_TAB_INDEX
     key = _normalize_expander_key(row_index)
     if key is None:
         return


### PR DESCRIPTION
## Summary
- ensure the stored tab state uses indices instead of labels for Streamlit tabs
- convert any legacy string-based tab state to a valid numeric index
- keep the SUD tab focus helper aligned with the new numeric state

## Testing
- python -m compileall lab_pg.py

------
https://chatgpt.com/codex/tasks/task_e_68d421d476a88326ad7e0432ab8b75ec