### PR TITLE
Refactor app: restructure sheets, add TIEMPOS logging, robust parsing and Streamlit UI rewrite

### DIFF
--- a/lab_pg.py
+++ b/lab_pg.py
@@ -1,11 +1,8 @@
-import colorsys
-import hashlib
 import json
-import re
+import math
 import unicodedata
-from datetime import date, datetime, time
-from functools import partial
-from io import BytesIO
+from datetime import date, datetime
+from typing import Any
 
 import gspread
 import pandas as pd
@@ -21,1178 +18,1070 @@ SCOPE = [
     "https://www.googleapis.com/auth/drive",
 ]
 
-DEFAULT_COLUMNS = [
-    "No_orden",
-    "Nombre_paciente",
-    "Nombre_doctor",
-    "Status",
-    "Status_NEMO",
-    "Tipo_alineador",
-    "Dias_entrega",
-    "Comentarios",
-    "Notas",
-    "Responsable_SUD",
-    "Fecha_inicio_SUD",
-    "Hora_inicio_SUD",
-    "Plantilla_superior",
-    "Plantilla_inferior",
-    "IPR",
-    "No_alineadores_superior",
-    "No_alineadores_inferior",
-    "Total_alineadores",
-    "Fecha_solicitud_envio",
-    "Ultima_Modificacion",
+SHEET_ESTATUS = "ESTATUS APARATOS"
+SHEET_PROCESOS = "PROCESOS POR APARATO"
+SHEET_TIEMPOS = "TIEMPOS_APARATOS"
+ID_COLUMN = "Columna 1"
+STATUS_COLUMN = "STATUS"
+
+TIEMPOS_HEADERS = [
+    "ID_LOG",
+    "Columna 1",
+    "APARATO",
+    "FASE_ORDEN",
+    "STATUS",
+    "STATUS_SIGUIENTE",
+    "RESPONSABLE",
+    "USUARIO",
+    "FECHA_INICIO",
+    "HORA_INICIO",
+    "FECHA_FIN",
+    "HORA_FIN",
+    "DURACION_HORAS",
+    "TIEMPO_MAXIMO_HORAS",
+    "ESTADO_ALERTA",
+    "COMENTARIOS_CAMBIO",
+    "FECHA_REGISTRO_LOG",
 ]
 
-RESPONSABLE_SUD_OPTIONS = [
-    "Selecciona",
-    "Arq Brenda",
-    "Karen",
-    "Melissa",
-    "Georgina",
-    "Carolina",
-    "Daniela",
+ACTIVE_USER_LABEL = "Usuario Streamlit"
+
+APARATO_OPTIONS = [
+    "MSE",
+    "TIGER",
+    "REVERSE",
+    "HYRAX",
+    "TRAMPA LINGUAL",
+    "LEONE",
+    "DISTALIZADOR",
 ]
 
-TAB_LABELS = ["➕ Nuevo Proceso", "SUD", "📋 Consulta"]
-_ACTIVE_TAB_QUERY_PARAM = "tab"
-_ACTIVE_TAB_STATE_KEY = "active_tab"
-_ACTIVE_TAB_INDEX_STATE_KEY = "active_tab_index"
-_SUD_TAB_LABEL = TAB_LABELS[1]
-SUD_EXPANDERS_STATE_KEY = "sud_expanders_state"
-
-_STATUS_LABELS = [
-    "1. Revisión de scan",
-    "2. Por hacer Setup",
-    "2.1 Scan con falla",
-    "3. RETENEDOR",
-    "3.1 RETENEDOR en proceso",
-    "3.2 SUD en proceso",
-    "3.3 SUD proceso modificación",
-    "4. Para revisión de SUD 1",
-    "4.1 Para revisión de SUD 2",
-    "5. Revisado – hay que modificar",
-    "5.1 Revisión alineación y nivelación",
-    "5.2 Revisión attachments y secuencia",
-    "5.3 Revisado VOBO y cotizar",
-    "6. Para cotización",
-    "7. Cotización lista",
-    "7.1 Listo para envío al Dr.",
-    "8. Enviado al Dr.",
-    "9. Solicitud cambios Dr.",
-    "10. Exportar modelos e imprimir",
-    "11. Imprimir modelo",
-    "12.1 Enviar biomodelos",
-    "12.3 Biomodelos enviados",
-    "13. Solo alineador",
-    "13.1 Para impresión",
-    "13.2 Reimpresión sin costo",
-    "14. Enviado a impresión",
-    "14.1 En impresión",
-    "15. Impresión perfecta",
-    "16. Error de impresión",
-    "17. En calidad",
-    "Revisados",
-    "Falta Pago",
-    "Esperando respuesta del Dr.",
-    "REFINAMIENTO",
-    "16. Enviado / empaquetado",
+STATUS_OPTIONS = [
+    "REVISION DE ARCHIVOS",
+    "EN PLANEACIÓN",
+    "REVISIÓN DEL DISEÑO POR DR",
+    "SOLICITUD DE CAMBIOS",
+    "ELABORACIÓN PLATINA BANDAS",
+    "ESPERANDO STL PSM",
+    "PDTE ENVIO PSM + GUIA",
+    "LISTO P/SINTERIZADO",
+    "EN SINTERIZADO",
+    "LISTO P/CONFECCIÓN",
+    "EN CONFECCIÓN",
+    "LISTO P/ENVÍO",
+    "ENVIADO",
+    "FALTA PAGO COMPLETO",
+    "CONFECCION EN PAUSA",
+    "CANCELO",
 ]
 
-_STATUS_NEMO_LABELS = [
-    "Nuevo",
-    "Carpeta específica",
-    "Duplicado",
-    "Seguimiento",
-    "Solo impresión",
+VENDEDOR_OPTIONS = [
+    "JIMENA",
+    "JUAN",
+    "MICHELLE",
+    "IGNACIO",
+    "KAREN",
+    "ALEJANDRA",
+    "CARO",
+    "HECTOR",
+    "DANIELA",
 ]
 
+SERVICIO_OPTIONS = [
+    "PLANEACIÓN COMPLETA",
+    "CONFECCIÓN",
+    "PLANEACIÓN & CONFECCIÓN",
+    "DISEÑO & CONFECCION",
+    "PLANEACION",
+]
 
-def _slugify_label(label: str) -> str:
-    normalized = unicodedata.normalize("NFKD", label)
-    ascii_label = "".join(c for c in normalized if not unicodedata.combining(c))
-    ascii_label = ascii_label.lower()
-    ascii_label = re.sub(r"[^a-z0-9]+", "_", ascii_label)
-    ascii_label = ascii_label.strip("_")
-    return ascii_label or "estado"
+ARCHIVOS_RECIBIDOS_OPTIONS = [
+    "STL",
+    "TOMOGRAFÍA",
+    "STL+TOMO",
+]
 
+PAGO_OPTIONS = [
+    "ANTICIPO",
+    "TOTAL",
+    "SIN PAGO",
+    "CANCELO",
+]
 
-def _generate_color(value: str, *, saturation: float = 0.65, lightness: float = 0.55) -> str:
-    digest = hashlib.sha1(value.encode("utf-8")).hexdigest()
-    hue = int(digest[:6], 16) / 0xFFFFFF
-    r, g, b = colorsys.hls_to_rgb(hue, lightness, saturation)
-    return "#{:02X}{:02X}{:02X}".format(int(r * 255), int(g * 255), int(b * 255))
+SELECTBOX_OPTIONS_BY_COLUMN = {
+    "APARATO": APARATO_OPTIONS,
+    STATUS_COLUMN: STATUS_OPTIONS,
+    "VENDEDOR": VENDEDOR_OPTIONS,
+    "SERVICIO": SERVICIO_OPTIONS,
+    "ARCHIVOS RECIBIDOS": ARCHIVOS_RECIBIDOS_OPTIONS,
+    "PAGO": PAGO_OPTIONS,
+}
 
+DATE_COLUMNS = {
+    "FECHA DE RECEPCIÓN",
+    "FECHA PAGO PLANEACION",
+    "FECHA PAGO CONFECCION",
+    "FECHA PARA ENTREGA",
+    "FECHA IMPRESIÓN",
+    "FECHA ENVÍO",
+}
 
-def _build_options(labels: list[str], prefix: str) -> list[dict[str, str]]:
-    options: list[dict[str, str]] = []
-    seen_values: set[str] = set()
-    for label in labels:
-        base_value = _slugify_label(label)
-        value = base_value
-        suffix = 1
-        while value in seen_values:
-            suffix += 1
-            value = f"{base_value}_{suffix}"
-        seen_values.add(value)
-        color = _generate_color(f"{prefix}_{value}")
-        options.append({"value": value, "label": label, "color": color})
-    return options
+DATETIME_TEXT_COLUMNS = {
+    "FECHA/HORA ENVÍO STEFANO",
+    "FECHA/HORA ENTREGA STEFANO",
+}
 
+TEXT_AREA_COLUMNS = {
+    "DETALLE COMENTARIOS",
+    "DETALLES & COMENTARIOS FINALES",
+}
 
-def _build_mappings(options: list[dict[str, str]]) -> tuple[dict[str, dict[str, str]], dict[str, dict[str, str]]]:
-    by_value = {opt["value"]: opt for opt in options}
-    by_label = {opt["label"]: opt for opt in options}
-    return by_value, by_label
-
-
-def _build_select_css(options: list[dict[str, str]]) -> str:
-    css_rules: list[str] = []
-    base_selector = 'div[data-baseweb="select"]'
-    for option in options:
-        label = option["label"]
-        color = option["color"]
-        safe_label = label.replace('"', '\\"')
-        selectors = [
-            f'{base_selector} [role="option"][aria-label="{safe_label}"]',
-            f'{base_selector} [role="option"][aria-label="{safe_label}"][aria-selected="true"]',
-            f'{base_selector} [aria-live="polite"] span[title="{safe_label}"]',
-            f'{base_selector} [aria-live="polite"] div[title="{safe_label}"]',
-            f'{base_selector} div[data-baseweb="tag"][title="{safe_label}"]',
-        ]
-        selector_block = ",\n".join(selectors)
-        css_rules.append(
-            f"{selector_block} {{ color: {color} !important; }}"
-        )
-    return "\n".join(css_rules)
-
-
-def _ensure_unique_column_names(df: pd.DataFrame) -> pd.DataFrame:
-    """Garantiza que todas las columnas del DataFrame tengan nombres únicos."""
-
-    if df.empty or df.columns.is_unique:
-        return df
-
-    new_columns: list[str] = []
-    counts: dict[str, int] = {}
-
-    for original_name in df.columns:
-        # Convertimos a string para evitar problemas con nombres no textuales.
-        base_name = str(original_name).strip()
-        if not base_name:
-            base_name = "Columna"
-
-        occurrence = counts.get(base_name, 0)
-        if occurrence == 0 and base_name not in new_columns:
-            new_name = base_name
-        else:
-            # Generamos sufijos incrementales hasta encontrar un nombre libre.
-            suffix = occurrence + 1
-            new_name = f"{base_name}_{suffix}"
-            while new_name in counts or new_name in new_columns:
-                suffix += 1
-                new_name = f"{base_name}_{suffix}"
-            counts[new_name] = 0
-
-        counts[base_name] = occurrence + 1
-        new_columns.append(new_name)
-
-    df = df.copy()
-    df.columns = new_columns
-    return df
+SPANISH_MONTHS = {
+    "ENERO": 1,
+    "FEBRERO": 2,
+    "MARZO": 3,
+    "ABRIL": 4,
+    "MAYO": 5,
+    "JUNIO": 6,
+    "JULIO": 7,
+    "AGOSTO": 8,
+    "SEPTIEMBRE": 9,
+    "SETIEMBRE": 9,
+    "OCTUBRE": 10,
+    "NOVIEMBRE": 11,
+    "DICIEMBRE": 12,
+}
 
 
-STATUS_OPTIONS = _build_options(_STATUS_LABELS, prefix="status")
-STATUS_OPTIONS_BY_VALUE, STATUS_OPTIONS_BY_LABEL = _build_mappings(STATUS_OPTIONS)
-STATUS_VALUES = [opt["value"] for opt in STATUS_OPTIONS]
+# ==============================
+# 🧰 UTILIDADES GENERALES
+# ==============================
+def normalize_text(value: Any) -> str:
+    """Normaliza texto para comparaciones tolerantes a mayúsculas y acentos."""
 
-STATUS_NEMO_OPTIONS = _build_options(_STATUS_NEMO_LABELS, prefix="status_nemo")
-STATUS_NEMO_BY_VALUE, STATUS_NEMO_BY_LABEL = _build_mappings(STATUS_NEMO_OPTIONS)
-STATUS_NEMO_VALUES = [opt["value"] for opt in STATUS_NEMO_OPTIONS]
-
-STATUS_SELECTBOX_CSS = _build_select_css(STATUS_OPTIONS)
-STATUS_NEMO_SELECTBOX_CSS = _build_select_css(STATUS_NEMO_OPTIONS)
-
-
-def format_status_option(value: str | None) -> str:
-    return _format_colored_option(
-        value,
-        STATUS_OPTIONS_BY_VALUE,
-    )
-
-
-def format_status_nemo_option(value: str | None) -> str:
-    return _format_colored_option(
-        value,
-        STATUS_NEMO_BY_VALUE,
-    )
-
-
-def _format_colored_option(
-    value: str | None,
-    mapping: dict[str, dict[str, str]],
-) -> str:
     if value is None:
         return ""
-    option = mapping.get(value)
-    if option is None:
-        return str(value)
-    return option["label"]
+    text = str(value).strip()
+    normalized = unicodedata.normalize("NFKD", text)
+    without_accents = "".join(
+        char for char in normalized if not unicodedata.combining(char)
+    )
+    return without_accents.upper()
 
 
-def _normalize_cell(value: str | None) -> str:
-    if value is None:
-        return ""
-    if isinstance(value, str):
-        text = value.strip()
-    else:
-        text = str(value)
-    return "" if text.lower() == "nan" else text
+def parse_simple_date(value: Any) -> date | None:
+    """Convierte fechas simples de Sheets a date cuando es seguro hacerlo."""
 
-
-def _resolve_option_data(
-    raw_value: str | None,
-    *,
-    by_value: dict[str, dict[str, str]],
-    by_label: dict[str, dict[str, str]],
-) -> tuple[str, str]:
-    cleaned_value = _normalize_cell(raw_value)
-    option = by_value.get(cleaned_value)
-    if option is None:
-        option = by_label.get(cleaned_value)
-    if option is None:
-        return cleaned_value, cleaned_value
-    return option["value"], option["label"]
-
-
-def _ensure_ui_state_defaults() -> None:
-    _ensure_active_tab_state()
-    if SUD_EXPANDERS_STATE_KEY not in st.session_state:
-        st.session_state[SUD_EXPANDERS_STATE_KEY] = {}
-
-
-def _ensure_active_tab_state() -> None:
-    params = st.query_params
-    values = params.get_all(_ACTIVE_TAB_QUERY_PARAM)
-    raw_index = values[0] if values else params.get(_ACTIVE_TAB_QUERY_PARAM)
-    index = _normalize_tab_index(raw_index)
-    label = TAB_LABELS[index]
-
-    st.session_state.setdefault(_ACTIVE_TAB_INDEX_STATE_KEY, index)
-    if st.session_state[_ACTIVE_TAB_INDEX_STATE_KEY] != index:
-        st.session_state[_ACTIVE_TAB_INDEX_STATE_KEY] = index
-
-    st.session_state.setdefault(_ACTIVE_TAB_STATE_KEY, label)
-    if st.session_state[_ACTIVE_TAB_STATE_KEY] != label:
-        st.session_state[_ACTIVE_TAB_STATE_KEY] = label
-
-    if raw_index != str(index):
-        st.query_params[_ACTIVE_TAB_QUERY_PARAM] = str(index)
-
-
-def _normalize_tab_index(raw_value) -> int:
-    try:
-        index = int(raw_value)
-    except (TypeError, ValueError):
-        index = 0
-    if index < 0:
-        index = 0
-    if index >= len(TAB_LABELS):
-        index = len(TAB_LABELS) - 1
-    return index
-
-
-def _set_active_tab(tab_label: str) -> None:
-    if tab_label not in TAB_LABELS:
-        return
-    index = TAB_LABELS.index(tab_label)
-    if st.session_state.get(_ACTIVE_TAB_STATE_KEY) != tab_label:
-        st.session_state[_ACTIVE_TAB_STATE_KEY] = tab_label
-    if st.session_state.get(_ACTIVE_TAB_INDEX_STATE_KEY) != index:
-        st.session_state[_ACTIVE_TAB_INDEX_STATE_KEY] = index
-    st.query_params[_ACTIVE_TAB_QUERY_PARAM] = str(index)
-
-
-def _render_tabs_with_state(labels: list[str]):
-    tabs = st.tabs(labels)
-    active_index = st.session_state.get(_ACTIVE_TAB_INDEX_STATE_KEY, 0)
-    active_index = _normalize_tab_index(active_index)
-    _emit_tab_selection_script(active_index)
-    return tabs
-
-
-def _emit_tab_selection_script(active_tab_index: int) -> None:
-    safe_labels = json.dumps(TAB_LABELS, ensure_ascii=False)
-    max_index = max(len(TAB_LABELS) - 1, 0)
-    normalized_index = min(max(int(active_tab_index or 0), 0), max_index)
-    script = f"""
-    <script>
-    const tabLabels = {safe_labels};
-    const activeTabIndex = {normalized_index};
-    const queryParam = {json.dumps(_ACTIVE_TAB_QUERY_PARAM)};
-    function updateQueryParam(index) {{
-        const url = new URL(window.parent.location.href);
-        url.searchParams.set(queryParam, index.toString());
-        window.parent.history.replaceState(null, '', url);
-    }}
-    function activateTab() {{
-        const tabButtons = window.parent.document.querySelectorAll('div[data-baseweb="tab-list"] button');
-        if (!tabButtons || tabButtons.length < tabLabels.length) {{
-            window.setTimeout(activateTab, 100);
-            return;
-        }}
-        tabButtons.forEach((button, index) => {{
-            if (!button.dataset.tabSyncAttached) {{
-                button.dataset.tabSyncAttached = 'true';
-                button.addEventListener('click', () => updateQueryParam(index), {{ once: false }});
-            }}
-            if (index === activeTabIndex && button.getAttribute('aria-selected') !== 'true') {{
-                button.click();
-            }}
-        }});
-    }}
-    activateTab();
-    </script>
-    """
-    st.markdown(script, unsafe_allow_html=True)
-
-
-def _normalize_expander_key(row_index) -> str | None:
-    if row_index is None:
+    text = clean_cell(value).strip()
+    if not text:
         return None
-    try:
-        return str(int(row_index))
-    except (TypeError, ValueError):
+
+    normalized = normalize_text(text).replace("/", "-")
+    parts = normalized.split()
+    if len(parts) >= 2 and parts[0].isdigit() and parts[1] in SPANISH_MONTHS:
+        year = datetime.now().year
+        if len(parts) >= 3 and parts[2].isdigit():
+            year = int(parts[2])
         try:
-            return str(row_index)
-        except Exception:
+            return date(year, SPANISH_MONTHS[parts[1]], int(parts[0]))
+        except ValueError:
             return None
 
-
-def _focus_sud_tab(row_index=None) -> None:
-    key = _normalize_expander_key(row_index)
-    if key is None:
-        return
-    _set_active_tab(_SUD_TAB_LABEL)
-    expanders_state = st.session_state.setdefault(SUD_EXPANDERS_STATE_KEY, {})
-    for existing_key in list(expanders_state.keys()):
-        expanders_state[existing_key] = existing_key == key
-    expanders_state[key] = True
+    parsed = pd.to_datetime(text, errors="coerce", dayfirst=True)
+    if pd.isna(parsed):
+        return None
+    return parsed.date()
 
 
-def _is_expander_marked_open(row_index) -> bool:
-    key = _normalize_expander_key(row_index)
-    if key is None:
+def is_numeric_value(value: Any) -> bool:
+    """Indica si un valor de celda puede editarse como número."""
+
+    text = clean_cell(value).strip()
+    if not text:
         return False
-    expanders_state = st.session_state.get(SUD_EXPANDERS_STATE_KEY, {})
-    return bool(expanders_state.get(key))
-
-# ==============================
-# 🔐 CLIENTE GOOGLE SHEETS
-# ==============================
-def _get_gs_client():
-    creds_str = st.secrets["gsheets"]["google_credentials"]  # 👈 viene como string
-    creds_info = json.loads(creds_str)  # 👈 lo convertimos en dict
-    credentials = Credentials.from_service_account_info(creds_info, scopes=SCOPE)
-    return gspread.authorize(credentials)
-    
-@st.cache_resource
-def get_worksheet():
-    client = _get_gs_client()
-    sheet_id = st.secrets["gsheets"]["sheet_id"]
-    ws_name = "Procesos_Graphy"
-
-    ss = client.open_by_key(sheet_id)
     try:
-        ws = ss.worksheet(ws_name)
-    except gspread.WorksheetNotFound:
-        ws = ss.add_worksheet(title=ws_name, rows="1000", cols=str(len(DEFAULT_COLUMNS)))
-        ws.update("A1", [DEFAULT_COLUMNS])
-    return ws
-
-
-@st.cache_data(ttl=30)
-def fetch_columns():
-    ws = get_worksheet()
-    headers = ws.row_values(1)
-    if headers:
-        return headers
-    ws.update("A1", [DEFAULT_COLUMNS])
-    return DEFAULT_COLUMNS.copy()
-
-@st.cache_data(ttl=30)
-def fetch_df():
-    ws = get_worksheet()
-    columns = fetch_columns()
-    values = ws.get_all_values()
-    if not values:
-        return pd.DataFrame(columns=columns)
-    df = pd.DataFrame(values[1:], columns=values[0])
-    required_columns = set(DEFAULT_COLUMNS)
-    required_columns.add("Fecha_recepcion")
-    for c in required_columns:
-        if c not in df.columns:
-            df[c] = ""
-    ordered_columns = columns + [
-        col for col in DEFAULT_COLUMNS if col not in columns
-    ]
-    extra_columns = [col for col in df.columns if col not in ordered_columns]
-    ordered_columns.extend(extra_columns)
-    return df[ordered_columns]
-
-def append_row(row):
-    ws = get_worksheet()
-    columns = fetch_columns()
-    values = [str(row.get(c, "")) if c in row else "" for c in columns]
-    ws.append_row(values, value_input_option="USER_ENTERED")
-
-
-def update_process(identifier, data_dict):
-    df = fetch_df()
-    if df.empty:
+        float(text.replace(",", "."))
+    except ValueError:
         return False
-
-    row_idx = None
-    current_no_orden = None
-
-    if isinstance(identifier, tuple):
-        if len(identifier) >= 2:
-            current_no_orden = identifier[0]
-            row_idx = identifier[1]
-        elif identifier:
-            current_no_orden = identifier[0]
-    elif isinstance(identifier, dict):
-        current_no_orden = identifier.get("No_orden")
-        row_idx = identifier.get("row_index")
-    else:
-        current_no_orden = identifier
-
-    if row_idx is not None:
-        try:
-            row_idx = int(row_idx)
-        except (TypeError, ValueError):
-            return False
-        if row_idx not in df.index:
-            return False
-        row_series = df.loc[row_idx]
-    else:
-        procesos = df[df["No_orden"].astype(str).str.strip() != ""]
-        if procesos.empty:
-            return False
-
-        current_no_orden = str(current_no_orden)
-        matching = procesos[procesos["No_orden"] == current_no_orden]
-        if matching.empty:
-            return False
-        row_idx = matching.index[0]
-        row_series = matching.iloc[0]
-
-    row_number = row_idx + 2  # encabezado +1
-
-    columns = fetch_columns()
-    column_positions = {name: idx + 1 for idx, name in enumerate(columns)}
-
-    updates: list[Cell] = []
-    for col, value in data_dict.items():
-        if col not in column_positions:
-            continue
-        updates.append(
-            Cell(
-                row=row_number,
-                col=column_positions[col],
-                value=_prepare_sheet_value(value),
-            )
-        )
-
-    if "Ultima_Modificacion" in column_positions:
-        updates.append(
-            Cell(
-                row=row_number,
-                col=column_positions["Ultima_Modificacion"],
-                value=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
-            )
-        )
-
-    if not updates:
-        return False
-
-    ws = get_worksheet()
-    ws.update_cells(updates)
     return True
 
 
-def _prepare_sheet_value(value):
+def build_selectbox_options(fixed_options: list[str], current_value: str) -> list[str]:
+    """Incluye temporalmente valores existentes que no están en el catálogo fijo."""
+
+    options = ["", *fixed_options]
+    if current_value and current_value not in options:
+        options.append(current_value)
+    return options
+
+
+def clean_cell(value: Any) -> str:
+    """Convierte celdas vacías/NaN en string vacío."""
+
+    if value is None:
+        return ""
+    if isinstance(value, float) and math.isnan(value):
+        return ""
+    text = str(value)
+    return "" if text.strip().lower() == "nan" else text
+
+
+def prepare_sheet_value(value: Any) -> str:
+    """Formatea valores para enviarlos de forma segura a Google Sheets."""
+
     if value is None:
         return ""
     if isinstance(value, datetime):
         return value.strftime("%Y-%m-%d %H:%M:%S")
     if isinstance(value, date):
         return value.isoformat()
-    if isinstance(value, time):
-        return value.strftime("%H:%M")
     if isinstance(value, float) and value.is_integer():
         value = int(value)
     return str(value)
 
 
-def _sync_total_alineadores(
+def ensure_unique_column_names(columns: list[str]) -> list[str]:
+    """Evita columnas duplicadas al mostrar hojas horizontales en DataFrame."""
+
+    counts: dict[str, int] = {}
+    unique_columns: list[str] = []
+    for index, raw_column in enumerate(columns):
+        base = str(raw_column).strip() or f"Columna_{index + 1}"
+        count = counts.get(base, 0)
+        column = base if count == 0 else f"{base}_{count + 1}"
+        while column in unique_columns:
+            count += 1
+            column = f"{base}_{count + 1}"
+        counts[base] = count + 1
+        unique_columns.append(column)
+    return unique_columns
+
+
+def parse_start_datetime(fecha: Any, hora: Any) -> datetime | None:
+    """Intenta construir un datetime desde fecha y hora de la hoja de tiempos."""
+
+    fecha_text = clean_cell(fecha).strip()
+    hora_text = clean_cell(hora).strip()
+    if not fecha_text:
+        return None
+
+    combined = f"{fecha_text} {hora_text}".strip()
+    parsed = pd.to_datetime(combined, errors="coerce", dayfirst=True)
+    if pd.isna(parsed):
+        parsed = pd.to_datetime(fecha_text, errors="coerce", dayfirst=True)
+    if pd.isna(parsed):
+        return None
+    return parsed.to_pydatetime()
+
+
+def calculate_duration_hours(start_dt: datetime | None, end_dt: datetime | None = None) -> str:
+    """Calcula duración decimal en horas entre dos momentos."""
+
+    if start_dt is None:
+        return ""
+    end_dt = end_dt or datetime.now()
+    duration = end_dt - start_dt
+    hours = duration.total_seconds() / 3600
+    return f"{max(hours, 0):.2f}"
+
+
+def calculate_alert_state(
+    fecha_inicio: Any,
+    hora_inicio: Any,
+    tiempo_maximo_horas: Any,
     *,
-    total_key: str,
-    sup_key: str,
-    inf_key: str,
-    sup_value=None,
-    inf_value=None,
-):
-    def _to_int(raw):
-        if raw is None:
-            return 0
-        if isinstance(raw, str):
-            raw = raw.strip()
-            if not raw:
-                return 0
-        try:
-            return int(raw)
-        except (TypeError, ValueError):
-            try:
-                return int(float(raw))
-            except (TypeError, ValueError):
-                return 0
+    now: datetime | None = None,
+) -> str:
+    """Calcula el estado visual de alerta para un registro activo."""
 
-    sup_raw = sup_value if sup_value is not None else st.session_state.get(sup_key, 0)
-    inf_raw = inf_value if inf_value is not None else st.session_state.get(inf_key, 0)
+    max_time_text = clean_cell(tiempo_maximo_horas).strip()
+    if not max_time_text:
+        return "Sin tiempo configurado"
 
-    total = _to_int(sup_raw) + _to_int(inf_raw)
-    return {"Total_alineadores": total}
-
-
-def persist_field_change(
-    identifier,
-    field_name,
-    *,
-    key,
-    transform=None,
-    extra_resolver=None,
-):
-    row_index = None
-    if isinstance(identifier, tuple) and len(identifier) >= 2:
-        row_index = identifier[1]
-    elif isinstance(identifier, dict):
-        row_index = identifier.get("row_index")
-
-    _focus_sud_tab(row_index)
-
-    raw_value = st.session_state.get(key)
     try:
-        value = transform(raw_value) if transform else raw_value
-    except Exception:
-        st.error(f"No se pudo procesar el campo {field_name}.")
-        return
+        max_hours = float(max_time_text.replace(",", "."))
+    except ValueError:
+        return "Sin tiempo configurado"
 
-    data = {field_name: _prepare_sheet_value(value)}
+    if max_hours <= 0:
+        return "Sin tiempo configurado"
 
-    if extra_resolver is not None:
-        try:
-            extra_data = extra_resolver(value)
-        except Exception:
-            st.error(
-                f"Ocurrió un problema al calcular valores derivados para {field_name}."
-            )
-            return
-        if extra_data:
-            data.update(
-                {
-                    extra_field: _prepare_sheet_value(extra_value)
-                    for extra_field, extra_value in extra_data.items()
-                }
-            )
+    start_dt = parse_start_datetime(fecha_inicio, hora_inicio)
+    if start_dt is None:
+        return "Sin fecha de inicio"
 
-    columns = fetch_columns()
-    filtered_data = {
-        col: val for col, val in data.items() if col in columns
-    }
-    if not filtered_data:
-        st.warning(
-            f"El campo {field_name} no existe en la hoja de cálculo actual."
+    now = now or datetime.now()
+    elapsed_hours = (now - start_dt).total_seconds() / 3600
+    if elapsed_hours >= max_hours:
+        return "Atrasado"
+    if elapsed_hours >= max_hours * 0.8:
+        return "Próximo a vencer"
+    return "En tiempo"
+
+
+# ==============================
+# 🔐 CLIENTE GOOGLE SHEETS
+# ==============================
+def _get_gs_client():
+    creds_str = st.secrets["gsheets"]["google_credentials"]
+    creds_info = json.loads(creds_str)
+    credentials = Credentials.from_service_account_info(creds_info, scopes=SCOPE)
+    return gspread.authorize(credentials)
+
+
+@st.cache_resource
+def get_spreadsheet():
+    client = _get_gs_client()
+    sheet_id = st.secrets["gsheets"]["sheet_id"]
+    return client.open_by_key(sheet_id)
+
+
+@st.cache_resource
+def get_worksheet(sheet_name: str):
+    spreadsheet = get_spreadsheet()
+    try:
+        return spreadsheet.worksheet(sheet_name)
+    except gspread.WorksheetNotFound:
+        if sheet_name != SHEET_TIEMPOS:
+            raise
+        return spreadsheet.add_worksheet(
+            title=SHEET_TIEMPOS,
+            rows="1000",
+            cols=str(len(TIEMPOS_HEADERS)),
         )
+
+
+def ensure_tiempos_headers() -> None:
+    """Asegura encabezados de TIEMPOS_APARATOS sin borrar datos existentes."""
+
+    worksheet = get_worksheet(SHEET_TIEMPOS)
+    headers = worksheet.row_values(1)
+    if not headers:
+        worksheet.update("A1", [TIEMPOS_HEADERS])
+        st.cache_data.clear()
         return
 
-    if update_process(identifier, filtered_data):
+    missing_headers = [header for header in TIEMPOS_HEADERS if header not in headers]
+    if missing_headers:
+        worksheet.update("A1", [headers + missing_headers])
         st.cache_data.clear()
-    else:
-        st.error(f"No se pudo actualizar el campo {field_name}.")
+
+
+@st.cache_data(ttl=30)
+def read_sheet_df(sheet_name: str) -> pd.DataFrame:
+    """Lee una hoja como DataFrame sin alterar sus encabezados existentes."""
+
+    worksheet = get_worksheet(sheet_name)
+    values = worksheet.get_all_values()
+    if not values:
+        if sheet_name == SHEET_TIEMPOS:
+            return pd.DataFrame(columns=TIEMPOS_HEADERS)
+        return pd.DataFrame()
+
+    header_row_index = 1 if sheet_name == SHEET_ESTATUS else 0
+    data_start_index = header_row_index + 1
+    if len(values) <= header_row_index:
+        return pd.DataFrame(columns=TIEMPOS_HEADERS if sheet_name == SHEET_TIEMPOS else [])
+
+    headers = values[header_row_index]
+    if not headers:
+        return pd.DataFrame(columns=TIEMPOS_HEADERS if sheet_name == SHEET_TIEMPOS else [])
+
+    unique_headers = ensure_unique_column_names(headers)
+    width = len(unique_headers)
+    normalized_rows = [
+        row[:width] + [""] * max(width - len(row), 0)
+        for row in values[data_start_index:]
+    ]
+    df = pd.DataFrame(normalized_rows, columns=unique_headers)
+
+    if sheet_name == SHEET_ESTATUS and not df.empty:
+        non_empty_rows = df.apply(
+            lambda row: any(clean_cell(value).strip() for value in row),
+            axis=1,
+        )
+        df = df[non_empty_rows]
+        if ID_COLUMN in df.columns:
+            has_identifier = df[ID_COLUMN].apply(lambda value: bool(clean_cell(value).strip()))
+            df = df[has_identifier]
+        df = df.reset_index(drop=True)
+
+    return df
+
+
+@st.cache_data(ttl=30)
+def read_sheet_values(sheet_name: str) -> list[list[str]]:
+    """Lee valores crudos para cálculos que dependen de estructura horizontal."""
+
+    return get_worksheet(sheet_name).get_all_values()
+
+
+def update_row_by_columna_1(identifier: str, changes: dict[str, Any]) -> bool:
+    """Actualiza solo las celdas modificadas de ESTATUS APARATOS por Columna 1."""
+
+    if not changes:
+        return False
+
+    worksheet = get_worksheet(SHEET_ESTATUS)
+    values = worksheet.get_all_values()
+    if not values:
+        return False
+
+    if len(values) < 2:
+        return False
+
+    headers = values[1]
+    if ID_COLUMN not in headers:
+        return False
+
+    id_index = headers.index(ID_COLUMN)
+    target_row_number: int | None = None
+    for row_number, row in enumerate(values[2:], start=3):
+        row_identifier = row[id_index] if id_index < len(row) else ""
+        if clean_cell(row_identifier).strip() == clean_cell(identifier).strip():
+            target_row_number = row_number
+            break
+
+    if target_row_number is None:
+        return False
+
+    column_positions = {column: index + 1 for index, column in enumerate(headers)}
+    updates = [
+        Cell(target_row_number, column_positions[column], prepare_sheet_value(value))
+        for column, value in changes.items()
+        if column in column_positions
+    ]
+    if not updates:
+        return False
+
+    worksheet.update_cells(updates, value_input_option="USER_ENTERED")
+    return True
+
+
+
+
+def find_first_empty_estatus_row() -> int:
+    """Encuentra la primera fila de ESTATUS APARATOS con Columna 1 vacía."""
+
+    worksheet = get_worksheet(SHEET_ESTATUS)
+    values = worksheet.get_all_values()
+
+    if len(values) < 2:
+        raise ValueError("No se encontraron encabezados en la fila 2 de ESTATUS APARATOS.")
+
+    headers = values[1]
+    if ID_COLUMN not in headers:
+        raise ValueError(f"No se encontró la columna {ID_COLUMN} en ESTATUS APARATOS.")
+
+    id_col_index = headers.index(ID_COLUMN)
+    for row_number, row in enumerate(values[2:], start=3):
+        current_id = row[id_col_index] if id_col_index < len(row) else ""
+        if not clean_cell(current_id).strip():
+            return row_number
+
+    return len(values) + 1
+
+
+def append_estatus_row(row_dict: dict[str, Any]) -> None:
+    """Escribe un nuevo pedido en el primer renglón disponible de ESTATUS APARATOS."""
+
+    worksheet = get_worksheet(SHEET_ESTATUS)
+    headers = worksheet.row_values(2)
+    if not headers:
+        raise ValueError("No se encontraron encabezados en la fila 2 de ESTATUS APARATOS.")
+
+    target_row = find_first_empty_estatus_row()
+    allowed_new_order_fields = {
+        ID_COLUMN,
+        "APARATO",
+        STATUS_COLUMN,
+        "NOMBRE DOCTOR",
+        "NOMBRE PACIENTE",
+        "DETALLE COMENTARIOS",
+        "VENDEDOR",
+        "SERVICIO",
+        "PAGO",
+        "DÍAS DE ENTREGA",
+        "FECHA PARA ENTREGA",
+    }
+    column_positions = {header: index + 1 for index, header in enumerate(headers)}
+
+    updates = []
+    for column, value in row_dict.items():
+        if column not in allowed_new_order_fields:
+            continue
+        if column not in column_positions:
+            continue
+        updates.append(
+            Cell(
+                row=target_row,
+                col=column_positions[column],
+                value=prepare_sheet_value(value),
+            )
+        )
+
+    if not updates:
+        raise ValueError("No hay campos válidos para guardar en ESTATUS APARATOS.")
+
+    worksheet.update_cells(updates, value_input_option="USER_ENTERED")
+
+
+def columna_1_exists(identifier: str) -> bool:
+    """Revisa si ya existe un identificador en Columna 1 de ESTATUS APARATOS."""
+
+    cleaned_identifier = clean_cell(identifier).strip()
+    if not cleaned_identifier:
+        return False
+
+    values = get_worksheet(SHEET_ESTATUS).get_all_values()
+    if len(values) < 2 or ID_COLUMN not in values[1]:
+        return False
+
+    id_index = values[1].index(ID_COLUMN)
+    for row in values[2:]:
+        existing_identifier = row[id_index] if id_index < len(row) else ""
+        if clean_cell(existing_identifier).strip() == cleaned_identifier:
+            return True
+    return False
+
+
+def get_next_log_id(tiempos_df: pd.DataFrame) -> int:
+    """Devuelve el siguiente ID_LOG consecutivo."""
+
+    if tiempos_df.empty or "ID_LOG" not in tiempos_df.columns:
+        return 1
+    numeric_ids = pd.to_numeric(tiempos_df["ID_LOG"], errors="coerce").dropna()
+    if numeric_ids.empty:
+        return 1
+    return int(numeric_ids.max()) + 1
+
+
+def find_tiempo_maximo_horas(apparatus: str, status: str) -> str:
+    """Busca de forma flexible el tiempo máximo en PROCESOS POR APARATO."""
+
+    values = read_sheet_values(SHEET_PROCESOS)
+    if not values or not apparatus or not status:
+        return ""
+
+    apparatus_norm = normalize_text(apparatus)
+    status_norm = normalize_text(status)
+    header = values[0]
+
+    for start_index, header_value in enumerate(header):
+        if apparatus_norm and apparatus_norm not in normalize_text(header_value):
+            continue
+
+        next_group_index = len(header)
+        for candidate_index in range(start_index + 1, len(header)):
+            candidate = normalize_text(header[candidate_index])
+            if candidate and "FASE" not in candidate and "TIEMPO" not in candidate:
+                next_group_index = candidate_index
+                break
+
+        group_headers = header[start_index:next_group_index]
+        phase_offsets = [
+            offset for offset, column in enumerate(group_headers) if "FASE" in normalize_text(column)
+        ]
+        time_offsets = [
+            offset for offset, column in enumerate(group_headers) if "TIEMPO" in normalize_text(column)
+        ]
+        if not phase_offsets or not time_offsets:
+            phase_offsets = [0]
+            time_offsets = [1] if next_group_index - start_index > 1 else []
+
+        for row in values[1:]:
+            for phase_offset in phase_offsets:
+                phase_index = start_index + phase_offset
+                phase_value = row[phase_index] if phase_index < len(row) else ""
+                if normalize_text(phase_value) != status_norm:
+                    continue
+
+                time_index = None
+                later_times = [offset for offset in time_offsets if offset > phase_offset]
+                if later_times:
+                    time_index = start_index + later_times[0]
+                elif time_offsets:
+                    time_index = start_index + time_offsets[0]
+
+                if time_index is not None and time_index < len(row):
+                    return clean_cell(row[time_index]).strip()
+    return ""
+
+
+def close_previous_active_time(identifier: str) -> bool:
+    """Cierra el registro activo anterior de TIEMPOS_APARATOS, si existe."""
+
+    worksheet = get_worksheet(SHEET_TIEMPOS)
+    values = worksheet.get_all_values()
+    if len(values) <= 1:
+        return False
+
+    headers = values[0]
+    required = [ID_COLUMN, "FECHA_INICIO", "HORA_INICIO", "FECHA_FIN", "HORA_FIN", "DURACION_HORAS"]
+    if any(column not in headers for column in required):
+        return False
+
+    id_index = headers.index(ID_COLUMN)
+    fecha_fin_index = headers.index("FECHA_FIN")
+    target_row_number: int | None = None
+    target_row: list[str] | None = None
+
+    for row_number, row in enumerate(values[1:], start=2):
+        row_identifier = row[id_index] if id_index < len(row) else ""
+        fecha_fin = row[fecha_fin_index] if fecha_fin_index < len(row) else ""
+        if clean_cell(row_identifier).strip() == clean_cell(identifier).strip() and not clean_cell(fecha_fin).strip():
+            target_row_number = row_number
+            target_row = row
+            break
+
+    if target_row_number is None or target_row is None:
+        return False
+
+    end_dt = datetime.now()
+    start_dt = parse_start_datetime(
+        target_row[headers.index("FECHA_INICIO")] if headers.index("FECHA_INICIO") < len(target_row) else "",
+        target_row[headers.index("HORA_INICIO")] if headers.index("HORA_INICIO") < len(target_row) else "",
+    )
+    updates = [
+        Cell(target_row_number, headers.index("FECHA_FIN") + 1, end_dt.strftime("%Y-%m-%d")),
+        Cell(target_row_number, headers.index("HORA_FIN") + 1, end_dt.strftime("%H:%M:%S")),
+        Cell(target_row_number, headers.index("DURACION_HORAS") + 1, calculate_duration_hours(start_dt, end_dt)),
+    ]
+    worksheet.update_cells(updates, value_input_option="USER_ENTERED")
+    return True
+
+
+def register_status_change(
+    *,
+    identifier: str,
+    apparatus: str,
+    previous_status: str,
+    new_status: str,
+    previous_identifier: str | None = None,
+    change_comment: str = "",
+) -> None:
+    """Registra el cambio de STATUS y abre un nuevo tiempo activo."""
+
+    ensure_tiempos_headers()
+    close_previous_active_time(previous_identifier or identifier)
+    st.cache_data.clear()
+
+    tiempos_df = read_sheet_df(SHEET_TIEMPOS)
+    now = datetime.now()
+    tiempo_maximo = find_tiempo_maximo_horas(apparatus, new_status)
+    default_comment = (
+        f"Cambio de status desde app: {previous_status or 'Sin status'} → {new_status}"
+    )
+    row = {
+        "ID_LOG": get_next_log_id(tiempos_df),
+        ID_COLUMN: identifier,
+        "APARATO": apparatus,
+        "FASE_ORDEN": "",
+        "STATUS": new_status,
+        "STATUS_SIGUIENTE": "",
+        "RESPONSABLE": "",
+        "USUARIO": ACTIVE_USER_LABEL,
+        "FECHA_INICIO": now.strftime("%Y-%m-%d"),
+        "HORA_INICIO": now.strftime("%H:%M:%S"),
+        "FECHA_FIN": "",
+        "HORA_FIN": "",
+        "DURACION_HORAS": "",
+        "TIEMPO_MAXIMO_HORAS": tiempo_maximo,
+        "ESTADO_ALERTA": "En tiempo",
+        "COMENTARIOS_CAMBIO": change_comment.strip() or default_comment,
+        "FECHA_REGISTRO_LOG": now.strftime("%Y-%m-%d %H:%M:%S"),
+    }
+    tiempos_worksheet = get_worksheet(SHEET_TIEMPOS)
+    current_headers = tiempos_worksheet.row_values(1) or TIEMPOS_HEADERS
+    tiempos_worksheet.append_row(
+        [prepare_sheet_value(row.get(column, "")) for column in current_headers],
+        value_input_option="USER_ENTERED",
+    )
+
+
+# ==============================
+# 🖥️ COMPONENTES STREAMLIT
+# ==============================
+def apply_estatus_filters(df: pd.DataFrame) -> pd.DataFrame:
+    """Renderiza filtros y devuelve la tabla filtrada."""
+
+    filtered_df = df.copy()
+    col_aparato, col_status, col_vendedor, col_pago, col_search = st.columns([1, 1, 1, 1, 1.4])
+
+    def options_for(column: str) -> list[str]:
+        if column not in df.columns:
+            return ["Todos"]
+        values = sorted({clean_cell(value).strip() for value in df[column] if clean_cell(value).strip()})
+        return ["Todos", *values]
+
+    with col_aparato:
+        aparato_filter = st.selectbox("APARATO", options_for("APARATO"))
+    with col_status:
+        status_filter = st.selectbox("STATUS", options_for(STATUS_COLUMN))
+    with col_vendedor:
+        vendedor_filter = st.selectbox("VENDEDOR", options_for("VENDEDOR"))
+    with col_pago:
+        pago_filter = st.selectbox("PAGO", options_for("PAGO"))
+    with col_search:
+        search_text = st.text_input("Buscar", placeholder="Columna 1, doctor o paciente")
+
+    for column, selected in {
+        "APARATO": aparato_filter,
+        STATUS_COLUMN: status_filter,
+        "VENDEDOR": vendedor_filter,
+        "PAGO": pago_filter,
+    }.items():
+        if selected != "Todos" and column in filtered_df.columns:
+            filtered_df = filtered_df[filtered_df[column].astype(str) == selected]
+
+    if search_text:
+        search_norm = normalize_text(search_text)
+        search_columns = [
+            column
+            for column in [ID_COLUMN, "NOMBRE DOCTOR", "NOMBRE PACIENTE"]
+            if column in filtered_df.columns
+        ]
+        if search_columns:
+            mask = filtered_df[search_columns].apply(
+                lambda row: search_norm in normalize_text(" ".join(row.astype(str))), axis=1
+            )
+            filtered_df = filtered_df[mask]
+
+    return filtered_df
+
+
+def render_edit_field(column: str, value: Any, key: str) -> Any:
+    """Renderiza un input seguro según la columna real de ESTATUS APARATOS."""
+
+    text_value = clean_cell(value)
+
+    if column == ID_COLUMN:
+        st.text_input(column, value=text_value, key=key, disabled=True)
+        return text_value
+
+    if column in SELECTBOX_OPTIONS_BY_COLUMN:
+        options = build_selectbox_options(SELECTBOX_OPTIONS_BY_COLUMN[column], text_value)
+        index = options.index(text_value) if text_value in options else 0
+        return st.selectbox(column, options, index=index, key=key)
+
+    if column in DATE_COLUMNS:
+        parsed_date = parse_simple_date(text_value)
+        if parsed_date is not None:
+            selected_date = st.date_input(column, value=parsed_date, key=key)
+            return text_value if selected_date == parsed_date else selected_date.isoformat()
+        return st.text_input(column, value=text_value, key=key)
+
+    if column in TEXT_AREA_COLUMNS:
+        return st.text_area(column, value=text_value, key=key, height=100)
+
+    if column == "DÍAS DE ENTREGA" and is_numeric_value(text_value):
+        numeric_value = float(text_value.replace(",", "."))
+        if numeric_value.is_integer():
+            return st.number_input(column, value=int(numeric_value), step=1, key=key)
+        return st.number_input(column, value=numeric_value, step=0.5, key=key)
+
+    return st.text_input(column, value=text_value, key=key)
+
+
+def render_optional_date_input(label: str, key: str) -> str:
+    """Permite guardar una fecha opcional sin establecer defaults no deseados."""
+
+    enabled = st.checkbox(f"Agregar {label}", key=f"{key}_enabled")
+    if not enabled:
+        return ""
+    return st.date_input(label, value=date.today(), key=key).isoformat()
+
+
+def render_nuevo_pedido_tab() -> None:
+    st.subheader("➕ Nuevo pedido")
+    st.caption("Agrega una nueva fila en ESTATUS APARATOS y crea el registro inicial en TIEMPOS_APARATOS.")
+
+    with st.form("form_nuevo_pedido"):
+        col_left, col_right = st.columns(2)
+
+        with col_left:
+            pedido_id = st.text_input("Columna 1 *")
+            aparato = st.selectbox("APARATO", APARATO_OPTIONS)
+            status = st.selectbox(
+                "STATUS",
+                STATUS_OPTIONS,
+                index=STATUS_OPTIONS.index("REVISION DE ARCHIVOS"),
+            )
+            nombre_doctor = st.text_input("NOMBRE DOCTOR")
+            nombre_paciente = st.text_input("NOMBRE PACIENTE")
+            detalle_comentarios = st.text_area("DETALLE COMENTARIOS", height=100)
+            vendedor = st.selectbox("VENDEDOR", ["", *VENDEDOR_OPTIONS])
+            servicio = st.selectbox("SERVICIO", ["", *SERVICIO_OPTIONS])
+            archivos_recibidos = st.selectbox(
+                "ARCHIVOS RECIBIDOS",
+                ["", *ARCHIVOS_RECIBIDOS_OPTIONS],
+            )
+            fecha_recepcion = st.date_input("FECHA DE RECEPCIÓN", value=date.today())
+
+        with col_right:
+            fecha_hora_envio_stefano = st.text_input("FECHA/HORA ENVÍO STEFANO")
+            fecha_hora_entrega_stefano = st.text_input("FECHA/HORA ENTREGA STEFANO")
+            pago = st.selectbox("PAGO", ["", *PAGO_OPTIONS])
+            fecha_pago_planeacion = render_optional_date_input(
+                "FECHA PAGO PLANEACION",
+                "nuevo_fecha_pago_planeacion",
+            )
+            fecha_pago_confeccion = render_optional_date_input(
+                "FECHA PAGO CONFECCION",
+                "nuevo_fecha_pago_confeccion",
+            )
+            dias_entrega = st.number_input("DÍAS DE ENTREGA", min_value=0, value=0, step=1)
+            fecha_para_entrega = render_optional_date_input(
+                "FECHA PARA ENTREGA",
+                "nuevo_fecha_para_entrega",
+            )
+            fecha_impresion = render_optional_date_input(
+                "FECHA IMPRESIÓN",
+                "nuevo_fecha_impresion",
+            )
+            fecha_envio = render_optional_date_input(
+                "FECHA ENVÍO",
+                "nuevo_fecha_envio",
+            )
+            detalles_finales = st.text_area("DETALLES & COMENTARIOS FINALES", height=100)
+
+        submitted = st.form_submit_button("💾 Guardar nuevo pedido")
+
+    if not submitted:
+        return
+
+    cleaned_identifier = clean_cell(pedido_id).strip()
+    if not cleaned_identifier:
+        st.error("Columna 1 es obligatoria.")
+        return
+
+    if columna_1_exists(cleaned_identifier):
+        st.error(f"Ya existe un pedido con Columna 1: {cleaned_identifier}")
+        return
+
+    row_dict = {
+        ID_COLUMN: cleaned_identifier,
+        "APARATO": aparato,
+        STATUS_COLUMN: status,
+        "NOMBRE DOCTOR": nombre_doctor,
+        "NOMBRE PACIENTE": nombre_paciente,
+        "DETALLE COMENTARIOS": detalle_comentarios,
+        "VENDEDOR": vendedor,
+        "SERVICIO": servicio,
+        "ARCHIVOS RECIBIDOS": archivos_recibidos,
+        "FECHA DE RECEPCIÓN": fecha_recepcion.isoformat(),
+        "FECHA/HORA ENVÍO STEFANO": fecha_hora_envio_stefano,
+        "FECHA/HORA ENTREGA STEFANO": fecha_hora_entrega_stefano,
+        "PAGO": pago,
+        "FECHA PAGO PLANEACION": fecha_pago_planeacion,
+        "FECHA PAGO CONFECCION": fecha_pago_confeccion,
+        "DÍAS DE ENTREGA": int(dias_entrega),
+        "FECHA PARA ENTREGA": fecha_para_entrega,
+        "FECHA IMPRESIÓN": fecha_impresion,
+        "FECHA ENVÍO": fecha_envio,
+        "DETALLES & COMENTARIOS FINALES": detalles_finales,
+    }
+
+    try:
+        append_estatus_row(row_dict)
+        register_status_change(
+            identifier=cleaned_identifier,
+            apparatus=aparato,
+            previous_status="",
+            new_status=status,
+            change_comment="Registro inicial desde app",
+        )
+    except Exception as exc:
+        st.error("No se pudo guardar el nuevo pedido.")
+        st.exception(exc)
+        return
+
+    st.cache_data.clear()
+    st.success("Nuevo pedido registrado correctamente.")
+    st.rerun()
+
+
+def render_estatus_tab() -> None:
+    st.subheader("📋 Seguimiento de pedidos")
+    estatus_df = read_sheet_df(SHEET_ESTATUS)
+
+    if estatus_df.empty:
+        st.info("La hoja ESTATUS APARATOS no tiene registros para mostrar.")
+        return
+    if ID_COLUMN not in estatus_df.columns:
+        st.error(f"No se encontró la columna obligatoria '{ID_COLUMN}' en ESTATUS APARATOS.")
+        return
+
+    filtered_df = apply_estatus_filters(estatus_df)
+    st.caption(f"Registros encontrados: {len(filtered_df)}")
+    st.dataframe(filtered_df, use_container_width=True, hide_index=True)
+
+    selectable_ids = [
+        clean_cell(value).strip()
+        for value in filtered_df[ID_COLUMN].tolist()
+        if clean_cell(value).strip()
+    ]
+    if not selectable_ids:
+        st.warning("No hay registros con Columna 1 para seleccionar en el resultado filtrado.")
+        return
+
+    selected_id = st.selectbox("Selecciona un registro por Columna 1", selectable_ids)
+    selected_rows = estatus_df[estatus_df[ID_COLUMN].astype(str).str.strip() == selected_id]
+    if selected_rows.empty:
+        st.warning("No se pudo encontrar el registro seleccionado.")
+        return
+
+    row = selected_rows.iloc[0]
+    st.markdown("### Editar registro seleccionado")
+    st.caption("Se actualizarán únicamente las columnas modificadas.")
+
+    with st.form(f"edit_estatus_{selected_id}"):
+        edited_values: dict[str, str] = {}
+        columns = list(estatus_df.columns)
+        for start in range(0, len(columns), 2):
+            left, right = st.columns(2)
+            for container, column in zip((left, right), columns[start : start + 2]):
+                with container:
+                    edited_values[column] = render_edit_field(
+                        column,
+                        row.get(column, ""),
+                        key=f"field_{selected_id}_{column}",
+                    )
+
+        change_comment = st.text_area(
+            "Comentario del cambio",
+            value="",
+            key=f"change_comment_{selected_id}",
+            help="Solo se guarda en TIEMPOS_APARATOS cuando cambia el STATUS.",
+        )
+        submitted = st.form_submit_button("💾 Guardar cambios")
+
+    if submitted:
+        changes = {
+            column: value
+            for column, value in edited_values.items()
+            if column != ID_COLUMN and clean_cell(value) != clean_cell(row.get(column, ""))
+        }
+        if not changes:
+            st.info("No se detectaron cambios para guardar.")
+            return
+
+        previous_status = clean_cell(row.get(STATUS_COLUMN, ""))
+        new_status = clean_cell(changes.get(STATUS_COLUMN, previous_status))
+        apparatus = clean_cell(changes.get("APARATO", row.get("APARATO", "")))
+
+        if update_row_by_columna_1(selected_id, changes):
+            if STATUS_COLUMN in changes and previous_status != new_status:
+                register_status_change(
+                    identifier=clean_cell(changes.get(ID_COLUMN, selected_id)).strip(),
+                    apparatus=apparatus,
+                    previous_status=previous_status,
+                    new_status=new_status,
+                    previous_identifier=selected_id,
+                    change_comment=change_comment,
+                )
+            st.cache_data.clear()
+            st.success("Registro actualizado correctamente.")
+            st.rerun()
+        else:
+            st.error("No se pudo actualizar el registro. Revisa que Columna 1 sea única y exista en la hoja.")
+
+
+def render_tiempos_tab() -> None:
+    st.subheader("⏱️ Tiempos y Alertas")
+    tiempos_df = read_sheet_df(SHEET_TIEMPOS)
+
+    if tiempos_df.empty:
+        st.info("TIEMPOS_APARATOS aún no tiene registros de cambios de status.")
+        return
+
+    for column in TIEMPOS_HEADERS:
+        if column not in tiempos_df.columns:
+            tiempos_df[column] = ""
+
+    active_mask = tiempos_df["FECHA_FIN"].astype(str).str.strip() == ""
+    tiempos_df["REGISTRO_ACTIVO"] = active_mask.map({True: "Sí", False: "No"})
+    tiempos_df["ESTADO_ALERTA_VISUAL"] = tiempos_df.apply(
+        lambda row: calculate_alert_state(
+            row.get("FECHA_INICIO", ""),
+            row.get("HORA_INICIO", ""),
+            row.get("TIEMPO_MAXIMO_HORAS", ""),
+        )
+        if clean_cell(row.get("FECHA_FIN", "")).strip() == ""
+        else clean_cell(row.get("ESTADO_ALERTA", "")) or "Cerrado",
+        axis=1,
+    )
+    tiempos_df["HORAS_TRANSCURRIDAS"] = tiempos_df.apply(
+        lambda row: calculate_duration_hours(
+            parse_start_datetime(row.get("FECHA_INICIO", ""), row.get("HORA_INICIO", ""))
+        )
+        if clean_cell(row.get("FECHA_FIN", "")).strip() == ""
+        else clean_cell(row.get("DURACION_HORAS", "")),
+        axis=1,
+    )
+
+    ordered_df = pd.concat([tiempos_df[active_mask], tiempos_df[~active_mask]], ignore_index=True)
+    st.dataframe(
+        ordered_df,
+        use_container_width=True,
+        hide_index=True,
+        column_config={
+            "ESTADO_ALERTA_VISUAL": st.column_config.TextColumn("Estado alerta visual"),
+            "HORAS_TRANSCURRIDAS": st.column_config.TextColumn("Horas transcurridas"),
+        },
+    )
+
+    counts = ordered_df["ESTADO_ALERTA_VISUAL"].value_counts().to_dict()
+    st.markdown("#### Resumen")
+    summary_cols = st.columns(4)
+    for container, label in zip(
+        summary_cols,
+        ["En tiempo", "Próximo a vencer", "Atrasado", "Sin tiempo configurado"],
+    ):
+        container.metric(label, counts.get(label, 0))
+
+
+def render_procesos_tab() -> None:
+    st.subheader("⚙️ Procesos por Aparato")
+    procesos_df = read_sheet_df(SHEET_PROCESOS)
+    if procesos_df.empty:
+        st.info("La hoja PROCESOS POR APARATO no tiene datos para mostrar.")
+        return
+    st.caption("Consulta de procesos y tiempos configurados. Esta hoja no se edita en esta versión.")
+    st.dataframe(procesos_df, use_container_width=True, hide_index=True)
+
 
 # ==============================
 # 🚀 APP STREAMLIT
 # ==============================
-st.set_page_config(page_title="Procesos – ARTTDLAB", layout="wide")
-st.title("🧪 Plataforma de Procesos – ARTTDLAB")
+st.set_page_config(page_title="Control de Aparatos – ARTTDLAB", layout="wide")
+st.title("🦷 Control de Aparatos – ARTTDLAB")
+st.caption("Primera versión para edición manual de estatus y registro automático de tiempos.")
 
-_ensure_ui_state_defaults()
+if st.button("🔄 Recargar datos", type="secondary"):
+    st.cache_data.clear()
+    st.cache_resource.clear()
+    st.rerun()
 
-tab1, tab_sud, tab2 = _render_tabs_with_state(TAB_LABELS)
-
-sheet_columns = fetch_columns()
-
-# ➕ NUEVO PROCESO
-with tab1:
-    st.subheader("🆕 Registrar nuevo proceso")
-
-    st.markdown(
-        "<style>\n"
-        f"{STATUS_SELECTBOX_CSS}\n"
-        f"{STATUS_NEMO_SELECTBOX_CSS}\n"
-        "</style>",
-        unsafe_allow_html=True,
+try:
+    ensure_tiempos_headers()
+    tab_nuevo, tab_seguimiento, tab_tiempos, tab_procesos = st.tabs(
+        [
+            "➕ Nuevo pedido",
+            "📋 Seguimiento de pedidos",
+            "⏱️ Tiempos y Alertas",
+            "⚙️ Procesos por Aparato",
+        ]
     )
 
-    with st.form("form_nuevo"):
-        in_paciente = st.text_input("🧑‍🦱 Nombre del paciente *")
-        in_doctor = st.text_input("🧑‍⚕️ Nombre del doctor *")
-        in_status = st.selectbox(
-            "📌 Status",
-            STATUS_VALUES,
-            format_func=format_status_option,
-        )
-        in_status_nemo = st.selectbox(
-            "🌐 Status en NEMO",
-            STATUS_NEMO_VALUES,
-            format_func=format_status_nemo_option,
-        )
-        in_tipo_alineador = st.selectbox(
-            "🦷 Tipo de alineador", ["Graphy", "Convencional"]
-        )
-        in_fecha_recepcion = None
-        if "Fecha_recepcion" in sheet_columns:
-            in_fecha_recepcion = st.date_input(
-                "📅 Fecha de recepción", datetime.today()
-            )
-        in_dias_entrega = st.number_input(
-            "⏳ Días de entrega", min_value=1, value=1, step=1
-        )
-        in_comentarios = st.text_area("💬 Comentarios")
-        in_notas = st.text_area("📝 Notas")
-        enviado = st.form_submit_button("💾 Guardar")
-
-    if enviado and in_paciente and in_doctor:
-        row: dict[str, str] = {}
-
-        if "No_orden" in sheet_columns:
-            row["No_orden"] = ""
-        if "Nombre_paciente" in sheet_columns:
-            row["Nombre_paciente"] = in_paciente
-        if "Nombre_doctor" in sheet_columns:
-            row["Nombre_doctor"] = in_doctor
-        if "Status" in sheet_columns:
-            row["Status"] = in_status
-        if "Status_NEMO" in sheet_columns:
-            row["Status_NEMO"] = in_status_nemo
-        if "Tipo_alineador" in sheet_columns:
-            row["Tipo_alineador"] = in_tipo_alineador
-        if "Fecha_recepcion" in sheet_columns and in_fecha_recepcion:
-            row["Fecha_recepcion"] = in_fecha_recepcion.strftime("%Y-%m-%d")
-        if "Dias_entrega" in sheet_columns:
-            row["Dias_entrega"] = str(int(in_dias_entrega))
-        if "Comentarios" in sheet_columns:
-            row["Comentarios"] = in_comentarios
-        if "Notas" in sheet_columns:
-            row["Notas"] = in_notas
-        if "Ultima_Modificacion" in sheet_columns:
-            row["Ultima_Modificacion"] = datetime.now().strftime(
-                "%Y-%m-%d %H:%M:%S"
-            )
-
-        append_row(row)
-        st.success("🎉 Proceso registrado correctamente.")
-        st.cache_data.clear()
-    elif enviado:
-        campos_faltantes = []
-        if not in_paciente:
-            campos_faltantes.append("Nombre del paciente")
-        if not in_doctor:
-            campos_faltantes.append("Nombre del doctor")
-
-        if campos_faltantes:
-            campos_texto = " y ".join(campos_faltantes)
-            prefijo = "los campos obligatorios" if len(campos_faltantes) > 1 else "el campo obligatorio"
-            st.error(f"⚠️ Por favor completa {prefijo}: {campos_texto}.")
-
-# 🧩 SUD
-with tab_sud:
-    st.subheader("Gestión de SUD")
-    df_sud = fetch_df()
-
-    if df_sud.empty:
-        st.info("No hay procesos disponibles para actualizar.")
-    else:
-        procesos = df_sud.copy()
-        has_fecha_recepcion = "Fecha_recepcion" in sheet_columns
-
-        st.markdown(
-            "<style>\n"
-            f"{STATUS_SELECTBOX_CSS}\n"
-            f"{STATUS_NEMO_SELECTBOX_CSS}\n"
-            "</style>",
-            unsafe_allow_html=True,
-        )
-
-        status_nemo_emojis = {
-            "Nuevo": "🆕",
-            "Carpeta específica": "📁",
-            "Duplicado": "🧬",
-            "Seguimiento": "📌",
-            "Solo impresión": "🖨️",
-        }
-
-        def _parse_date(value):
-            try:
-                return datetime.strptime(value, "%Y-%m-%d").date()
-            except Exception:
-                return None
-
-        def _parse_time(value):
-            for fmt in ("%H:%M", "%H:%M:%S"):
-                try:
-                    return datetime.strptime(value, fmt).time()
-                except Exception:
-                    continue
-            return None
-
-        def _parse_int(value, default=0):
-            if value is None:
-                return default
-            if isinstance(value, str):
-                cleaned = value.strip()
-                if not cleaned or cleaned.lower() == "nan":
-                    return default
-                value = cleaned
-            try:
-                return int(float(value))
-            except (TypeError, ValueError):
-                return default
-
-        for idx, row in procesos.iterrows():
-            no_orden = str(row.get("No_orden", "") or "").strip()
-            if no_orden.lower() == "nan":
-                no_orden = ""
-            paciente = str(row.get("Nombre_paciente", "") or "").strip() or "Sin nombre"
-            doctor = str(row.get("Nombre_doctor", "") or "").strip() or "Sin doctor"
-
-            status_value, status_label = _resolve_option_data(
-                row.get("Status"),
-                by_value=STATUS_OPTIONS_BY_VALUE,
-                by_label=STATUS_OPTIONS_BY_LABEL,
-            )
-            status_options = STATUS_VALUES.copy()
-            if status_value and status_value not in status_options:
-                status_options.append(status_value)
-
-            status_label_display = status_label or "Sin status"
-
-            (
-                status_nemo_value,
-                status_nemo_label,
-            ) = _resolve_option_data(
-                row.get("Status_NEMO"),
-                by_value=STATUS_NEMO_BY_VALUE,
-                by_label=STATUS_NEMO_BY_LABEL,
-            )
-            status_nemo_options = STATUS_NEMO_VALUES.copy()
-            if status_nemo_value and status_nemo_value not in status_nemo_options:
-                status_nemo_options.append(status_nemo_value)
-            status_nemo_label = status_nemo_label or "Sin status NEMO"
-            status_nemo_emoji = status_nemo_emojis.get(status_nemo_label, "❓")
-            expander_title = " • ".join(
-                [
-                    f"{status_nemo_emoji} {paciente} – {doctor}",
-                    status_label_display,
-                    status_nemo_label,
-                ]
-            )
-
-            identifier = (no_orden if no_orden else None, idx)
-
-            fecha_recepcion_val = None
-            if has_fecha_recepcion:
-                fecha_recepcion_val = _parse_date(row.get("Fecha_recepcion", ""))
-            fecha_inicio_val = _parse_date(row.get("Fecha_inicio_SUD", ""))
-            fecha_solicitud_val = _parse_date(row.get("Fecha_solicitud_envio", ""))
-            hora_inicio_val = _parse_time(row.get("Hora_inicio_SUD", ""))
-
-            dias_entrega_val = max(
-                1, _parse_int(row.get("Dias_entrega", "1"), default=1)
-            )
-            comentarios_default = _normalize_cell(row.get("Comentarios", ""))
-            notas_default = _normalize_cell(row.get("Notas", ""))
-
-            tipo_alineador_default = _normalize_cell(row.get("Tipo_alineador", ""))
-            tipo_alineador_default = tipo_alineador_default or "Graphy"
-            tipo_alineador_options = ["Graphy", "Convencional"]
-            if tipo_alineador_default not in tipo_alineador_options:
-                tipo_alineador_options.append(tipo_alineador_default)
-
-            status_index = (
-                status_options.index(status_value)
-                if status_value in status_options
-                else 0
-            )
-            status_nemo_index = (
-                status_nemo_options.index(status_nemo_value)
-                if status_nemo_value in status_nemo_options
-                else 0
-            )
-            tipo_alineador_index = (
-                tipo_alineador_options.index(tipo_alineador_default)
-                if tipo_alineador_default in tipo_alineador_options
-                else 0
-            )
-
-            responsable_default = row.get("Responsable_SUD", "")
-            responsable_options = RESPONSABLE_SUD_OPTIONS.copy()
-            if (
-                responsable_default
-                and responsable_default not in responsable_options
-            ):
-                responsable_options.append(responsable_default)
-            responsable_index = (
-                responsable_options.index(responsable_default)
-                if responsable_default in responsable_options
-                else 0
-            )
-
-            form_key = f"form_sud_{idx}"
-            with st.expander(
-                expander_title,
-                expanded=_is_expander_marked_open(idx),
-            ):
-                st.caption(
-                    f"No. orden: {no_orden if no_orden else 'Sin número de orden'} | "
-                    f"Status NEMO ID: {status_nemo_value or 'N/D'}"
-                )
-
-                col_left, col_right = st.columns(2)
-                save_field = partial(persist_field_change, identifier)
-
-                with col_left:
-                    no_orden_key = f"{form_key}_no_orden"
-                    st.text_input(
-                        "🔢 No. orden",
-                        value=no_orden,
-                        key=no_orden_key,
-                        on_change=save_field,
-                        args=("No_orden",),
-                        kwargs={
-                            "key": no_orden_key,
-                            "transform": lambda v: (v or "").strip(),
-                        },
-                    )
-
-                    status_key = f"{form_key}_status"
-                    st.selectbox(
-                        "📌 Status",
-                        status_options,
-                        index=status_index,
-                        format_func=format_status_option,
-                        key=status_key,
-                        on_change=save_field,
-                        args=("Status",),
-                        kwargs={"key": status_key},
-                    )
-
-                    status_nemo_key = f"{form_key}_status_nemo"
-                    st.selectbox(
-                        "🌐 Status en NEMO",
-                        status_nemo_options,
-                        index=status_nemo_index,
-                        format_func=format_status_nemo_option,
-                        key=status_nemo_key,
-                        on_change=save_field,
-                        args=("Status_NEMO",),
-                        kwargs={"key": status_nemo_key},
-                    )
-
-                    tipo_alineador_key = f"{form_key}_tipo_alineador"
-                    st.selectbox(
-                        "🦷 Tipo de alineador",
-                        tipo_alineador_options,
-                        index=tipo_alineador_index,
-                        key=tipo_alineador_key,
-                        on_change=save_field,
-                        args=("Tipo_alineador",),
-                        kwargs={"key": tipo_alineador_key},
-                    )
-
-                    if has_fecha_recepcion:
-                        fecha_recepcion_key = f"{form_key}_fecha_recepcion"
-                        st.date_input(
-                            "📅 Fecha de recepción",
-                            value=fecha_recepcion_val or datetime.today().date(),
-                            key=fecha_recepcion_key,
-                            on_change=save_field,
-                            args=("Fecha_recepcion",),
-                            kwargs={"key": fecha_recepcion_key},
-                        )
-
-                    dias_entrega_key = f"{form_key}_dias_entrega"
-                    st.number_input(
-                        "⏳ Días de entrega",
-                        min_value=1,
-                        value=int(dias_entrega_val),
-                        step=1,
-                        key=dias_entrega_key,
-                        on_change=save_field,
-                        args=("Dias_entrega",),
-                        kwargs={
-                            "key": dias_entrega_key,
-                            "transform": lambda v: int(v) if v is not None else 0,
-                        },
-                    )
-
-                    comentarios_key = f"{form_key}_comentarios"
-                    st.text_area(
-                        "💬 Comentarios",
-                        value=comentarios_default,
-                        key=comentarios_key,
-                        on_change=save_field,
-                        args=("Comentarios",),
-                        kwargs={"key": comentarios_key},
-                        height=150,
-                    )
-
-                    notas_key = f"{form_key}_notas"
-                    st.text_area(
-                        "📝 Notas",
-                        value=notas_default,
-                        key=notas_key,
-                        on_change=save_field,
-                        args=("Notas",),
-                        kwargs={"key": notas_key},
-                        height=150,
-                    )
-
-                with col_right:
-                    responsable_key = f"{form_key}_responsable"
-                    st.selectbox(
-                        "🧑‍🔧 Responsable hacer SUD",
-                        responsable_options,
-                        index=responsable_index,
-                        key=responsable_key,
-                        on_change=save_field,
-                        args=("Responsable_SUD",),
-                        kwargs={
-                            "key": responsable_key,
-                            "transform": lambda v: "" if v in ("", "Selecciona") else v,
-                        },
-                    )
-
-                    fecha_inicio_key = f"{form_key}_fecha_inicio"
-                    st.date_input(
-                        "📅 Fecha inicio SUD",
-                        value=fecha_inicio_val or datetime.today().date(),
-                        key=fecha_inicio_key,
-                        on_change=save_field,
-                        args=("Fecha_inicio_SUD",),
-                        kwargs={"key": fecha_inicio_key},
-                    )
-
-                    hora_inicio_key = f"{form_key}_hora_inicio"
-                    st.time_input(
-                        "⏰ Hora de inicio",
-                        value=(
-                            hora_inicio_val
-                            or datetime.now().time().replace(second=0, microsecond=0)
-                        ),
-                        key=hora_inicio_key,
-                        on_change=save_field,
-                        args=("Hora_inicio_SUD",),
-                        kwargs={"key": hora_inicio_key},
-                    )
-
-                    plantilla_sup_key = f"{form_key}_plantilla_sup"
-                    st.text_input(
-                        "📄 Plantilla superior",
-                        value=row.get("Plantilla_superior", ""),
-                        key=plantilla_sup_key,
-                        on_change=save_field,
-                        args=("Plantilla_superior",),
-                        kwargs={
-                            "key": plantilla_sup_key,
-                            "transform": lambda v: v.strip() if isinstance(v, str) else v,
-                        },
-                    )
-
-                    plantilla_inf_key = f"{form_key}_plantilla_inf"
-                    st.text_input(
-                        "📄 Plantilla inferior",
-                        value=row.get("Plantilla_inferior", ""),
-                        key=plantilla_inf_key,
-                        on_change=save_field,
-                        args=("Plantilla_inferior",),
-                        kwargs={
-                            "key": plantilla_inf_key,
-                            "transform": lambda v: v.strip() if isinstance(v, str) else v,
-                        },
-                    )
-
-                    ipr_value = row.get("IPR")
-                    ipr_default = "No"
-                    if isinstance(ipr_value, bool):
-                        ipr_default = "Sí" if ipr_value else "No"
-                    elif ipr_value is not None:
-                        normalized_ipr = (
-                            unicodedata.normalize("NFKD", ipr_value)
-                            if isinstance(ipr_value, str)
-                            else str(ipr_value)
-                        )
-                        normalized_ipr = "".join(
-                            c for c in normalized_ipr if not unicodedata.combining(c)
-                        ).strip().lower()
-                        if normalized_ipr in {"x", "si", "s", "true", "1", "yes"}:
-                            ipr_default = "Sí"
-
-                    ipr_key = f"{form_key}_ipr"
-                    ipr_options = ["Sí", "No"]
-                    ipr_index = (
-                        ipr_options.index(ipr_default) if ipr_default in ipr_options else 1
-                    )
-
-                    st.radio(
-                        "⚙️ IPR",
-                        options=ipr_options,
-                        index=ipr_index,
-                        key=ipr_key,
-                        on_change=save_field,
-                        args=("IPR",),
-                        kwargs={
-                            "key": ipr_key,
-                            "transform": lambda v: "Sí" if v == "Sí" else "No",
-                        },
-                    )
-
-                    total_key = f"{form_key}_total_alineadores"
-                    no_sup_key = f"{form_key}_no_sup"
-                    no_sup = st.number_input(
-                        "🔢 No. alineadores superior",
-                        min_value=0,
-                        value=_parse_int(row.get("No_alineadores_superior", "0")),
-                        step=1,
-                        key=no_sup_key,
-                        on_change=save_field,
-                        args=("No_alineadores_superior",),
-                        kwargs={
-                            "key": no_sup_key,
-                            "transform": lambda v: int(v) if v is not None else 0,
-                            "extra_resolver": lambda value,
-                            sup_key=no_sup_key,
-                            inf_key=f"{form_key}_no_inf",
-                            total_key=total_key: _sync_total_alineadores(
-                                total_key=total_key,
-                                sup_key=sup_key,
-                                inf_key=inf_key,
-                                sup_value=value,
-                            ),
-                        },
-                    )
-
-                    no_inf_key = f"{form_key}_no_inf"
-                    no_inf = st.number_input(
-                        "🔢 No. alineadores inferior",
-                        min_value=0,
-                        value=_parse_int(row.get("No_alineadores_inferior", "0")),
-                        step=1,
-                        key=no_inf_key,
-                        on_change=save_field,
-                        args=("No_alineadores_inferior",),
-                        kwargs={
-                            "key": no_inf_key,
-                            "transform": lambda v: int(v) if v is not None else 0,
-                            "extra_resolver": lambda value,
-                            sup_key=no_sup_key,
-                            inf_key=no_inf_key,
-                            total_key=total_key: _sync_total_alineadores(
-                                total_key=total_key,
-                                sup_key=sup_key,
-                                inf_key=inf_key,
-                                inf_value=value,
-                            ),
-                        },
-                    )
-
-                    try:
-                        total_calculado = int(no_sup) + int(no_inf)
-                    except (TypeError, ValueError):
-                        total_calculado = 0
-
-                    st.number_input(
-                        "🧮 Total alineadores",
-                        min_value=0,
-                        value=total_calculado,
-                        step=1,
-                        disabled=True,
-                        key=total_key,
-                    )
-
-                    fecha_solicitud_key = f"{form_key}_fecha_solicitud"
-                    st.date_input(
-                        "📬 Fecha solicitud de envío",
-                        value=fecha_solicitud_val or datetime.today().date(),
-                        key=fecha_solicitud_key,
-                        on_change=save_field,
-                        args=("Fecha_solicitud_envio",),
-                        kwargs={"key": fecha_solicitud_key},
-                    )
-
-# 📋 CONSULTA
-with tab2:
-    st.subheader("Listado de procesos")
-    df = fetch_df()
-    if df.empty:
-        st.info("No hay procesos registrados aún.")
-    else:
-        df_display = df.copy()
-        if not df_display.empty:
-            status_info = df_display.apply(
-                lambda row: _resolve_option_data(
-                    row.get("Status"),
-                    by_value=STATUS_OPTIONS_BY_VALUE,
-                    by_label=STATUS_OPTIONS_BY_LABEL,
-                ),
-                axis=1,
-                result_type="expand",
-            )
-            status_info.columns = [
-                "Status_Value",
-                "Status_Label",
-            ]
-            df_display["Status"] = status_info["Status_Label"]
-
-            nemo_info = df_display.apply(
-                lambda row: _resolve_option_data(
-                    row.get("Status_NEMO"),
-                    by_value=STATUS_NEMO_BY_VALUE,
-                    by_label=STATUS_NEMO_BY_LABEL,
-                ),
-                axis=1,
-                result_type="expand",
-            )
-            nemo_info.columns = [
-                "Status_NEMO_Value",
-                "Status_NEMO_Label",
-            ]
-            df_display["Status_NEMO"] = nemo_info["Status_NEMO_Label"]
-
-        excel_buffer = BytesIO()
-        df_display = df_display.drop(
-            columns=["Status_Color", "Status_NEMO_Color"], errors="ignore"
-        )
-        df_display = _ensure_unique_column_names(df_display)
-        df_display.to_excel(excel_buffer, index=False, sheet_name="Procesos")
-        excel_buffer.seek(0)
-
-        st.download_button(
-            "⬇️ Descargar Excel",
-            data=excel_buffer,
-            file_name=f"procesos_{datetime.now().strftime('%Y%m%d_%H%M%S')}.xlsx",
-            mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-        )
-
-        st.dataframe(df_display, use_container_width=True, height=600)
+    with tab_nuevo:
+        render_nuevo_pedido_tab()
+    with tab_seguimiento:
+        render_estatus_tab()
+    with tab_tiempos:
+        render_tiempos_tab()
+    with tab_procesos:
+        render_procesos_tab()
+except Exception as exc:
+    st.error("Ocurrió un problema al cargar la app.")
+    st.exception(exc)


### PR DESCRIPTION
### Motivation
- Simplify and standardize spreadsheet model by separating `ESTATUS APARATOS`, `PROCESOS POR APARATO` and `TIEMPOS_APARATOS` and improve reliability when reading/writing. 
- Add proper audit/logging of status changes and duration tracking to automate alerting and time calculations. 
- Remove brittle custom UI helpers (color hashing / slugify) and replace with robust normalization, parsing and safe Sheet I/O utilities. 
- Rework Streamlit flows to safer form-based operations and stricter validation to avoid accidental writes and duplicate identifiers.

### Description
- Reorganized constants and option catalogs (e.g. `SHEET_ESTATUS`, `SHEET_TIEMPOS`, `STATUS_OPTIONS`, `APARATO_OPTIONS`) and removed legacy color/slug utilities. 
- Added generic utilities: `normalize_text`, `clean_cell`, `prepare_sheet_value`, `parse_simple_date`, `ensure_unique_column_names`, `parse_start_datetime`, `calculate_duration_hours` and `calculate_alert_state` to normalize cell handling and compute durations/alerts. 
- Reworked Google Sheets client and accessors: introduced `get_spreadsheet`, cached `get_worksheet(sheet_name)`, `read_sheet_df(sheet_name)`, `read_sheet_values(sheet_name)`, and `ensure_tiempos_headers()` to safely read/write sheets and preserve headers. 
- Implemented ETL and write helpers for app flows: `update_row_by_columna_1`, `append_estatus_row`, `columna_1_exists`, `get_next_log_id`, `find_tiempo_maximo_horas`, `close_previous_active_time`, and `register_status_change` which manage ESTATUS and TIEMPOS interactions and ensure only changed cells are updated. 
- Rebuilt Streamlit app UI into focused tabs and components: `render_nuevo_pedido_tab`, `render_estatus_tab`, `render_tiempos_tab`, `render_procesos_tab`, with safer form handling, validations (unique `Columna 1`), and automatic TIEMPOS logging on status changes. 

### Testing
- No automated tests were added or modified as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a271a6c8c7c8326add28c5e4c49aed8)