### PR TITLE
Include initial STATUS in ESTATUS APARATOS when creating new order

### DIFF
--- a/lab_pg.py
+++ b/lab_pg.py
@@ -1084,7 +1084,10 @@ def render_optional_date_input(label: str, key: str) -> str:
 
 def render_nuevo_pedido_tab() -> None:
     st.subheader("➕ Nuevo pedido")
-    st.caption("Captura únicamente los datos iniciales del pedido.")
+    st.caption(
+        "Captura los datos principales en ESTATUS APARATOS; "
+        "TIEMPOS_APARATOS solo recibe el log complementario para tiempos y alertas."
+    )
 
     with st.form("form_nuevo_pedido"):
         col_left, col_right = st.columns(2)
@@ -1140,9 +1143,12 @@ def render_nuevo_pedido_tab() -> None:
     clean_servicio = clean_display_value(servicio)
     clean_pago = clean_display_value(pago)
 
+    default_status = STATUS_OPTIONS[0] if STATUS_OPTIONS else ""
+
     row_dict = {
         ID_COLUMN: cleaned_identifier,
         "APARATO": clean_aparato,
+        STATUS_COLUMN: default_status,
         "NOMBRE DOCTOR": nombre_doctor,
         "NOMBRE PACIENTE": nombre_paciente,
         "DETALLE COMENTARIOS": detalle_comentarios,
@@ -1155,7 +1161,6 @@ def render_nuevo_pedido_tab() -> None:
 
     try:
         append_estatus_row(row_dict)
-        default_status = STATUS_OPTIONS[0] if STATUS_OPTIONS else ""
         if default_status:
             register_status_change(
                 identifier=cleaned_identifier,
@@ -1170,7 +1175,9 @@ def render_nuevo_pedido_tab() -> None:
         return
 
     st.cache_data.clear()
-    st.success("Nuevo pedido capturado en la primera fila disponible.")
+    st.success(
+        "Nuevo pedido guardado en ESTATUS APARATOS y log inicial registrado en TIEMPOS_APARATOS."
+    )
     st.rerun()
 
 


### PR DESCRIPTION
### Motivation
- El flujo actual debía dejar los datos principales del pedido en la hoja `ESTATUS APARATOS` y usar `TIEMPOS_APARATOS` solo como log de tiempos/alertas, pero el `STATUS` inicial no se estaba guardando en la fila principal de ESTATUS al crear un pedido desde la app.

### Description
- Actualicé el texto guía de la pestaña "Nuevo pedido" para aclarar que los datos principales se guardan en `ESTATUS APARATOS` y que `TIEMPOS_APARATOS` solo recibe el log complementario para tiempos y alertas.
- Incluí el `STATUS` inicial (primer valor de `STATUS_OPTIONS`) en el `row_dict` que se escribe en `ESTATUS APARATOS` al crear un nuevo pedido.
- Reorganicé la creación del `default_status` para calcularlo antes de armar `row_dict` y mantener la lógica original que registra el log inicial en `TIEMPOS_APARATOS` mediante `register_status_change`.
- Actualicé el mensaje de éxito para indicar claramente que el pedido se guardó en `ESTATUS APARATOS` y que se registró el log inicial en `TIEMPOS_APARATOS`.

### Testing
- Ejecuté `python -m py_compile lab_pg.py` y la compilación fue satisfactoria.
- Ejecuté una comprobación interna con un pequeño script que valida que el campo de `STATUS` fue incluido antes de la llamada a `append_estatus_row`, y la aserción pasó correctamente.
- Inicié un arranque de humo con `python -m streamlit run lab_pg.py --server.headless true --server.port 8501` para verificar que la app arranca (se inició correctamente y paró por timeout del entorno), sin errores de import/ejecución automáticos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a274c2f819c8326b4a659714f1ab653)