### PR TITLE
Mejoras: coincidencia flexible de encabezados, operaciones robustas en ESTATUS APARATOS y feedback de 'Nuevo pedido'

### DIFF
--- a/lab_pg.py
+++ b/lab_pg.py
@@ -421,6 +421,35 @@ def ensure_unique_column_names(columns: list[str]) -> list[str]:
     return unique_columns
 
 
+def canonical_header_key(value: Any) -> str:
+    """Normaliza encabezados de Sheets ignorando saltos de línea y espacios extra."""
+
+    return " ".join(normalize_text(value).split())
+
+
+def build_header_positions(headers: list[str]) -> dict[str, int]:
+    """Mapea encabezados a posiciones 1-based con comparación flexible."""
+
+    positions: dict[str, int] = {}
+    for index, header in enumerate(headers, start=1):
+        cleaned_header = clean_cell(header).strip()
+        if cleaned_header and cleaned_header not in positions:
+            positions[cleaned_header] = index
+
+        canonical_header = canonical_header_key(header)
+        if canonical_header and canonical_header not in positions:
+            positions[canonical_header] = index
+
+    return positions
+
+
+def get_header_position(headers: list[str], column: str) -> int | None:
+    """Devuelve la posición 1-based de una columna aceptando encabezados con saltos."""
+
+    positions = build_header_positions(headers)
+    return positions.get(column) or positions.get(canonical_header_key(column))
+
+
 def parse_start_datetime(fecha: Any, hora: Any) -> datetime | None:
     """Intenta construir un datetime desde fecha y hora de la hoja de tiempos."""
 
@@ -595,10 +624,11 @@ def update_row_by_columna_1(identifier: str, changes: dict[str, Any]) -> bool:
         return False
 
     headers = values[1]
-    if ID_COLUMN not in headers:
+    id_position = get_header_position(headers, ID_COLUMN)
+    if id_position is None:
         return False
 
-    id_index = headers.index(ID_COLUMN)
+    id_index = id_position - 1
     target_row_number: int | None = None
     for row_number, row in enumerate(values[2:], start=3):
         row_identifier = row[id_index] if id_index < len(row) else ""
@@ -609,12 +639,14 @@ def update_row_by_columna_1(identifier: str, changes: dict[str, Any]) -> bool:
     if target_row_number is None:
         return False
 
-    column_positions = {column: index + 1 for index, column in enumerate(headers)}
-    updates = [
-        Cell(target_row_number, column_positions[column], prepare_sheet_value(value))
-        for column, value in changes.items()
-        if column in column_positions
-    ]
+    updates = []
+    for column, value in changes.items():
+        column_position = get_header_position(headers, column)
+        if column_position is None:
+            continue
+        updates.append(
+            Cell(target_row_number, column_position, prepare_sheet_value(value))
+        )
     if not updates:
         return False
 
@@ -623,71 +655,145 @@ def update_row_by_columna_1(identifier: str, changes: dict[str, Any]) -> bool:
 
 
 
+NEW_ORDER_ESTATUS_FIELDS = [
+    ID_COLUMN,
+    "APARATO",
+    STATUS_COLUMN,
+    "NOMBRE DOCTOR",
+    "NOMBRE PACIENTE",
+    "DETALLE COMENTARIOS",
+    "VENDEDOR",
+    "SERVICIO",
+    "ARCHIVOS RECIBIDOS",
+    "PAGO",
+    "DÍAS DE ENTREGA",
+    "FECHA DE RECEPCIÓN",
+    "FECHA PARA ENTREGA",
+]
 
-def find_first_empty_estatus_row() -> int:
-    """Encuentra la primera fila de ESTATUS APARATOS con Columna 1 vacía."""
 
-    worksheet = get_worksheet(SHEET_ESTATUS)
-    values = worksheet.get_all_values()
+def find_first_available_estatus_row(values: list[list[str]], headers: list[str]) -> int:
+    """Encuentra la primera fila donde Columna 1 esté vacía."""
 
-    if len(values) < 2:
-        raise ValueError("No se encontraron encabezados en la fila 2 de ESTATUS APARATOS.")
-
-    headers = values[1]
-    if ID_COLUMN not in headers:
+    id_position = get_header_position(headers, ID_COLUMN)
+    if id_position is None:
         raise ValueError(f"No se encontró la columna {ID_COLUMN} en ESTATUS APARATOS.")
 
-    id_col_index = headers.index(ID_COLUMN)
+    id_index = id_position - 1
     for row_number, row in enumerate(values[2:], start=3):
-        current_id = row[id_col_index] if id_col_index < len(row) else ""
+        current_id = row[id_index] if id_index < len(row) else ""
         if not clean_cell(current_id).strip():
             return row_number
 
     return len(values) + 1
 
 
-def append_estatus_row(row_dict: dict[str, Any]) -> None:
-    """Escribe un nuevo pedido en el primer renglón disponible de ESTATUS APARATOS."""
+def append_estatus_row(
+    row_dict: dict[str, Any], debug_info: dict[str, Any] | None = None
+) -> int:
+    """Escribe un nuevo pedido en ESTATUS APARATOS y devuelve el renglón usado."""
 
     worksheet = get_worksheet(SHEET_ESTATUS)
-    headers = worksheet.row_values(2)
-    if not headers:
+    values = worksheet.get_all_values()
+    if len(values) < 2:
+        if debug_info is not None:
+            debug_info.update(
+                {
+                    "sheet": SHEET_ESTATUS,
+                    "status": "error",
+                    "reason": "No se encontraron encabezados en la fila 2.",
+                }
+            )
         raise ValueError("No se encontraron encabezados en la fila 2 de ESTATUS APARATOS.")
 
-    target_row = find_first_empty_estatus_row()
-    allowed_new_order_fields = {
-        ID_COLUMN,
-        "APARATO",
-        STATUS_COLUMN,
-        "NOMBRE DOCTOR",
-        "NOMBRE PACIENTE",
-        "DETALLE COMENTARIOS",
-        "VENDEDOR",
-        "SERVICIO",
-        "PAGO",
-        "DÍAS DE ENTREGA",
-        "FECHA PARA ENTREGA",
-    }
-    column_positions = {header: index + 1 for index, header in enumerate(headers)}
+    headers = values[1]
+    target_row = find_first_available_estatus_row(values, headers)
+    id_position = get_header_position(headers, ID_COLUMN)
 
     updates = []
-    for column, value in row_dict.items():
-        if column not in allowed_new_order_fields:
+    columns_debug = []
+    for column in NEW_ORDER_ESTATUS_FIELDS:
+        if column not in row_dict:
             continue
-        if column not in column_positions:
+
+        prepared_value = prepare_sheet_value(row_dict[column])
+        column_position = get_header_position(headers, column)
+        columns_debug.append(
+            {
+                "column": column,
+                "found": column_position is not None,
+                "sheet_column_number": column_position,
+                "value_to_write": prepared_value,
+            }
+        )
+        if column_position is None:
             continue
+
         updates.append(
             Cell(
                 row=target_row,
-                col=column_positions[column],
-                value=prepare_sheet_value(value),
+                col=column_position,
+                value=prepared_value,
             )
         )
 
+    if debug_info is not None:
+        debug_info.update(
+            {
+                "intent": "Guardar nuevo pedido en ESTATUS APARATOS",
+                "sheet": SHEET_ESTATUS,
+                "headers_row": 2,
+                "target_row": target_row,
+                "target_reason": f"Primera fila donde {ID_COLUMN} está vacía",
+                "id_column_number": id_position,
+                "input_id": prepare_sheet_value(row_dict.get(ID_COLUMN, "")),
+                "columns": columns_debug,
+                "updates_count": len(updates),
+            }
+        )
+
     if not updates:
+        if debug_info is not None:
+            debug_info.update(
+                {
+                    "status": "error",
+                    "reason": "No se encontraron columnas válidas para escribir.",
+                }
+            )
         raise ValueError("No hay campos válidos para guardar en ESTATUS APARATOS.")
 
-    worksheet.update_cells(updates, value_input_option="USER_ENTERED")
+    try:
+        worksheet.update_cells(updates, value_input_option="USER_ENTERED")
+    except Exception as exc:
+        if debug_info is not None:
+            debug_info.update(
+                {
+                    "status": "error",
+                    "reason": f"Google Sheets rechazó update_cells: {exc}",
+                }
+            )
+        raise
+
+    if debug_info is not None:
+        read_back_row = worksheet.row_values(target_row)
+        read_back = {}
+        for column_debug in columns_debug:
+            column_position = column_debug["sheet_column_number"]
+            if column_position is None:
+                continue
+            row_index = column_position - 1
+            read_back[column_debug["column"]] = (
+                read_back_row[row_index] if row_index < len(read_back_row) else ""
+            )
+        debug_info.update(
+            {
+                "status": "success",
+                "reason": "update_cells enviado y fila leída después de guardar.",
+                "read_back": read_back,
+            }
+        )
+
+    return target_row
 
 
 def columna_1_exists(identifier: str) -> bool:
@@ -698,10 +804,14 @@ def columna_1_exists(identifier: str) -> bool:
         return False
 
     values = get_worksheet(SHEET_ESTATUS).get_all_values()
-    if len(values) < 2 or ID_COLUMN not in values[1]:
+    if len(values) < 2:
         return False
 
-    id_index = values[1].index(ID_COLUMN)
+    id_position = get_header_position(values[1], ID_COLUMN)
+    if id_position is None:
+        return False
+
+    id_index = id_position - 1
     for row in values[2:]:
         existing_identifier = row[id_index] if id_index < len(row) else ""
         if clean_cell(existing_identifier).strip() == cleaned_identifier:
@@ -1082,9 +1192,55 @@ def render_optional_date_input(label: str, key: str) -> str:
     ).isoformat()
 
 
+def render_success_feedback(
+    message_key: str, celebrate_key: str, clear_button_key: str
+) -> None:
+    """Muestra éxito persistente con toast, globos y botón para limpiar."""
+
+    message = st.session_state.get(message_key)
+    if not message:
+        return
+
+    if st.session_state.pop(celebrate_key, False):
+        st.toast(message, icon="✅")
+        st.balloons()
+
+    st.success(message)
+    if st.button("✅ Aceptar y limpiar mensaje", key=clear_button_key):
+        st.session_state.pop(message_key, None)
+        st.session_state.pop("nuevo_pedido_debug", None)
+        st.rerun()
+
+
+def render_nuevo_pedido_debug() -> None:
+    """Muestra el diagnóstico del último intento de guardado de Nuevo pedido."""
+
+    debug_info = st.session_state.get("nuevo_pedido_debug")
+    if not debug_info:
+        return
+
+    status = debug_info.get("status", "sin estado")
+    target_row = debug_info.get("target_row", "sin fila")
+    st.caption(
+        f"🔎 Diagnóstico Nuevo pedido: {debug_info.get('sheet', SHEET_ESTATUS)} "
+        f"→ fila {target_row} → {status}"
+    )
+    with st.expander("🔎 Ver diagnóstico del último guardado", expanded=status != "success"):
+        st.json(debug_info)
+
+
 def render_nuevo_pedido_tab() -> None:
     st.subheader("➕ Nuevo pedido")
-    st.caption("Captura únicamente los datos iniciales del pedido.")
+    st.caption(
+        "Captura los datos principales en ESTATUS APARATOS; "
+        "TIEMPOS_APARATOS solo recibe el log complementario para tiempos y alertas."
+    )
+    render_success_feedback(
+        "nuevo_pedido_success_message",
+        "nuevo_pedido_show_celebration",
+        "clear_nuevo_pedido_success",
+    )
+    render_nuevo_pedido_debug()
 
     with st.form("form_nuevo_pedido"):
         col_left, col_right = st.columns(2)
@@ -1110,9 +1266,18 @@ def render_nuevo_pedido_tab() -> None:
                 display_field_label("SERVICIO"),
                 build_display_selectbox_options("SERVICIO", SERVICIO_OPTIONS, ""),
             )
+            archivos_recibidos = st.selectbox(
+                display_field_label("ARCHIVOS RECIBIDOS"),
+                build_display_selectbox_options(
+                    "ARCHIVOS RECIBIDOS", ARCHIVOS_RECIBIDOS_OPTIONS, ""
+                ),
+            )
             pago = st.selectbox(
                 display_field_label("PAGO"),
                 build_display_selectbox_options("PAGO", PAGO_OPTIONS, ""),
+            )
+            fecha_recepcion = st.date_input(
+                display_field_label("FECHA DE RECEPCIÓN"), value=date.today()
             )
             dias_entrega = st.number_input(
                 display_field_label("DÍAS DE ENTREGA"), min_value=0, value=0, step=1
@@ -1138,25 +1303,47 @@ def render_nuevo_pedido_tab() -> None:
     clean_aparato = clean_display_value(aparato)
     clean_vendedor = clean_display_value(vendedor)
     clean_servicio = clean_display_value(servicio)
+    clean_archivos_recibidos = clean_display_value(archivos_recibidos)
     clean_pago = clean_display_value(pago)
+
+    default_status = STATUS_OPTIONS[0] if STATUS_OPTIONS else ""
 
     row_dict = {
         ID_COLUMN: cleaned_identifier,
         "APARATO": clean_aparato,
+        STATUS_COLUMN: default_status,
         "NOMBRE DOCTOR": nombre_doctor,
         "NOMBRE PACIENTE": nombre_paciente,
         "DETALLE COMENTARIOS": detalle_comentarios,
         "VENDEDOR": clean_vendedor,
         "SERVICIO": clean_servicio,
+        "ARCHIVOS RECIBIDOS": clean_archivos_recibidos,
         "PAGO": clean_pago,
         "DÍAS DE ENTREGA": int(dias_entrega),
+        "FECHA DE RECEPCIÓN": fecha_recepcion.isoformat(),
         "FECHA PARA ENTREGA": fecha_para_entrega.isoformat(),
     }
 
+    estatus_debug: dict[str, Any] = {
+        "intent": "Guardar nuevo pedido en ESTATUS APARATOS",
+        "sheet": SHEET_ESTATUS,
+        "input_id": cleaned_identifier,
+        "status": "starting",
+    }
+    st.session_state["nuevo_pedido_debug"] = estatus_debug
+
     try:
-        append_estatus_row(row_dict)
-        default_status = STATUS_OPTIONS[0] if STATUS_OPTIONS else ""
-        if default_status:
+        target_row = append_estatus_row(row_dict, estatus_debug)
+    except Exception as exc:
+        st.session_state["nuevo_pedido_debug"] = estatus_debug
+        st.error("No se pudo guardar el nuevo pedido en ESTATUS APARATOS.")
+        render_nuevo_pedido_debug()
+        st.exception(exc)
+        return
+
+    timing_log_saved = False
+    if default_status:
+        try:
             register_status_change(
                 identifier=cleaned_identifier,
                 apparatus=clean_aparato,
@@ -1164,13 +1351,36 @@ def render_nuevo_pedido_tab() -> None:
                 new_status=default_status,
                 change_comment="Registro inicial desde app",
             )
-    except Exception as exc:
-        st.error("No se pudo guardar el nuevo pedido.")
-        st.exception(exc)
-        return
+            timing_log_saved = True
+            estatus_debug["tiempos_log"] = {
+                "sheet": SHEET_TIEMPOS,
+                "status": "success",
+                "reason": "Log inicial registrado después de guardar ESTATUS APARATOS.",
+            }
+        except Exception as exc:
+            estatus_debug["tiempos_log"] = {
+                "sheet": SHEET_TIEMPOS,
+                "status": "error",
+                "reason": f"No se pudo registrar el log inicial: {exc}",
+            }
+            st.warning(
+                "El pedido sí se guardó en ESTATUS APARATOS, "
+                "pero no se pudo registrar el log inicial en TIEMPOS_APARATOS."
+            )
+            st.exception(exc)
 
     st.cache_data.clear()
-    st.success("Nuevo pedido capturado en la primera fila disponible.")
+    log_text = (
+        "y también se registró el log inicial en TIEMPOS_APARATOS"
+        if timing_log_saved
+        else "pero quedó pendiente el log inicial en TIEMPOS_APARATOS"
+    )
+    st.session_state["nuevo_pedido_success_message"] = (
+        f"Pedido {cleaned_identifier} guardado en ESTATUS APARATOS "
+        f"en la fila {target_row}; {log_text}."
+    )
+    st.session_state["nuevo_pedido_debug"] = estatus_debug
+    st.session_state["nuevo_pedido_show_celebration"] = True
     st.rerun()
 
 


### PR DESCRIPTION
### Motivation
- Evitar fallos por variaciones en encabezados de Sheets (saltos de línea, espacios) usando una comparación más tolerante al buscar columnas. 
- Hacer las operaciones de escritura en la hoja `ESTATUS APARATOS` más robustas y observables frente a errores de Google Sheets. 
- Registrar y presentar diagnóstico cuando se crea un nuevo pedido para facilitar el soporte y evitar datos huérfanos en `TIEMPOS_APARATOS`. 
- Mejorar la UX del formulario de `Nuevo pedido` con campos adicionales y mensajes de éxito persistentes.

### Description
- Se añadieron utilidades de normalización y búsqueda de encabezados: `canonical_header_key`, `build_header_positions` y `get_header_position`, y se adaptaron múltiples funciones para usar búsqueda flexible de columnas. 
- Se refactorizaron funciones relacionadas con ESTATUS APARATOS: `update_row_by_columna_1` ahora usa `get_header_position`; `find_first_available_estatus_row` reemplaza la versión anterior y acepta la matriz de valores y encabezados; y `columna_1_exists` usa la nueva búsqueda de encabezados. 
- `append_estatus_row` ahora devuelve la fila usada y acepta un `debug_info` opcional, respeta el orden definido por `NEW_ORDER_ESTATUS_FIELDS`, arma `Cell` con `prepare_sheet_value`, captura errores de `update_cells`, hace lectura de verificación posterior y añade información diagnóstica detallada. 
- Se añadieron componentes de UI y lógica: `render_success_feedback` y `render_nuevo_pedido_debug`, el tab `render_nuevo_pedido_tab` incorpora nuevos campos (`ARCHIVOS RECIBIDOS`, `FECHA DE RECEPCIÓN`), establece `STATUS_COLUMN` por defecto, guarda el `nuevo_pedido_debug` en `st.session_state`, intenta registrar el log inicial en `TIEMPOS_APARATOS` y presenta mensajes/celebraciones según resultado. 

### Testing
- No se ejecutaron pruebas automatizadas durante este cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a274c2f819c8326b4a659714f1ab653)