### PR TITLE
Sync table selection with selectbox, improve Estefano Forms UI, and split Estefano tabs

### DIFF
--- a/lab_pg.py
+++ b/lab_pg.py
@@ -1,3 +1,4 @@
+import html
 import json
 import math
 import unicodedata
@@ -3010,30 +3011,53 @@ def filter_estatus_by_status(statuses: list[str]) -> pd.DataFrame:
     ].copy()
 
 
+def apply_single_row_selection_to_selectbox(
+    event: Any, df: pd.DataFrame, id_column: str, selectbox_key: str
+) -> None:
+    """Sincroniza una fila seleccionada en una tabla con su selectbox asociado."""
+
+    selected_rows = getattr(getattr(event, "selection", None), "rows", [])
+    if not selected_rows:
+        return
+    selected_position = selected_rows[0]
+    if selected_position >= len(df.index):
+        return
+    raw_selected_id = df.iloc[selected_position].get(id_column, "")
+    selected_id = clean_cell(raw_selected_id).strip()
+    if selected_id:
+        st.session_state[selectbox_key] = raw_selected_id
+
+
 def render_case_selector(cases_df: pd.DataFrame, key: str) -> tuple[str, pd.Series | None]:
-    """Muestra tabla y selector común para pestañas por usuario."""
+    """Muestra tabla seleccionable y selector común para pestañas por usuario."""
 
     if cases_df.empty:
         st.info("No hay casos para esta pestaña.")
         return "", None
     st.caption(f"Registros encontrados: {len(cases_df)}")
-    st.dataframe(
+    table_event = st.dataframe(
         cases_df,
         use_container_width=True,
         hide_index=True,
         column_config=build_dataframe_column_config(cases_df),
+        on_select="rerun",
+        selection_mode="single-row",
+        key=f"{key}_table",
     )
+    apply_single_row_selection_to_selectbox(table_event, cases_df, ID_COLUMN, key)
     ids = [clean_cell(value).strip() for value in cases_df[ID_COLUMN].tolist() if clean_cell(value).strip()]
     ids = list(dict.fromkeys(ids))
     if not ids:
         st.warning("No hay registros con Columna 1 para seleccionar.")
         return "", None
+    if st.session_state.get(key) not in ids:
+        st.session_state[key] = ids[0]
     labels = {}
     for _, row in cases_df.iterrows():
         identifier = clean_cell(row.get(ID_COLUMN, "")).strip()
         if identifier and identifier not in labels:
             labels[identifier] = (
-                f"🆔 {identifier} | {display_selectbox_value(STATUS_COLUMN, clean_cell(row.get(STATUS_COLUMN, '')).strip())} | "
+                f"🆔 {identifier} | 🚦 {display_selectbox_value(STATUS_COLUMN, clean_cell(row.get(STATUS_COLUMN, '')).strip())} | "
                 f"👩‍⚕️ {clean_cell(row.get('NOMBRE DOCTOR', '')).strip()} | 🙂 {clean_cell(row.get('NOMBRE PACIENTE', '')).strip()}"
             )
     selected_id = st.selectbox("Selecciona Columna 1", ids, format_func=lambda option: labels.get(option, option), key=key)
@@ -3169,14 +3193,34 @@ def upload_payment_receipt_to_s3(identifier: str, uploaded_file: Any) -> str:
     return key
 
 
+
+def get_forms_field_icon(column: str) -> str:
+    """Devuelve un icono específico para que la ficha de Forms no se vea repetitiva."""
+
+    normalized = normalize_text(column)
+    icon_rules = [
+        (("MARCA", "FECHA", "HORA", "TEMPORAL"), "🕒"),
+        (("DOCTOR", "TRATANTE", "MEDICO"), "🩺"),
+        (("WHATSAPP", "TELEFONO", "CONTACTO"), "💬"),
+        (("PACIENTE",), "🙂"),
+        (("APARATO", "SOLICITAR", "OPCIONES"), "🦷"),
+        (("ARCHIVO", "STL", "DICOM", "DRIVE", "ADJUNTAR"), "📎"),
+        (("OBSERV", "COMENT", "DETALLE", "INDICACION"), "📝"),
+        (("DIRECCION", "ENVIO", "DOMICILIO"), "📍"),
+        (("CORREO", "EMAIL", "MAIL"), "✉️"),
+    ]
+    for keywords, icon in icon_rules:
+        if any(keyword in normalized for keyword in keywords):
+            return icon
+    return "🔹"
+
 def render_estefano_forms_review(can_edit: bool) -> None:
     """Muestra respuestas del Google Form para tomar links de Drive en revisión."""
 
-    st.markdown("### 📄 Respuestas de Google Forms")
+    st.markdown("### 📋 Recibidos desde Forms")
     st.caption(
-        "Usa esta sección solo como bandeja de revisión: muestra todas las columnas "
-        "útiles del Excel de Forms, ocultando únicamente aceptación de términos y "
-        "textos legales. También permite copiar el link de Drive al formulario de Estefano."
+        "Primero elige la respuesta; abajo verás una ficha tipo resumen con iconos "
+        "distintos por dato, sin líneas azules largas ni texto amontonado."
     )
 
     forms_config = get_forms_config()
@@ -3204,9 +3248,10 @@ def render_estefano_forms_review(can_edit: bool) -> None:
         st.info("No hay respuestas de Google Forms para mostrar.")
         return
     file_column = get_forms_file_column(review_df)
+    display_df = review_df.sort_values("Respuesta #", ascending=False).head(25).reset_index(drop=True)
 
-    st.dataframe(
-        review_df.sort_values("Respuesta #", ascending=False).head(25),
+    table_event = st.dataframe(
+        display_df,
         use_container_width=True,
         hide_index=True,
         column_config=(
@@ -3214,48 +3259,93 @@ def render_estefano_forms_review(can_edit: bool) -> None:
             if file_column
             else None
         ),
+        on_select="rerun",
+        selection_mode="single-row",
+        key="forms_response_table_estefano",
+    )
+    apply_single_row_selection_to_selectbox(
+        table_event, display_df, "Respuesta #", "forms_response_selector_estefano"
     )
 
-    response_options = review_df["Respuesta #"].tolist()
+    response_options = display_df["Respuesta #"].tolist()
+    if st.session_state.get("forms_response_selector_estefano") not in response_options:
+        st.session_state["forms_response_selector_estefano"] = response_options[0]
     selected_response = st.selectbox(
-        "Selecciona una respuesta para usar su link de Drive",
+        "📌 Selecciona una respuesta para usar su link de Drive",
         options=response_options,
-        index=len(response_options) - 1,
         disabled=not can_edit,
         key="forms_response_selector_estefano",
     )
-    selected_rows = review_df[review_df["Respuesta #"] == selected_response]
+    selected_rows = display_df[display_df["Respuesta #"] == selected_response]
     if selected_rows.empty:
         return
 
     selected_row = selected_rows.iloc[0]
     selected_link = clean_cell(selected_row.get(file_column, "")).strip() if file_column else ""
-    detail_columns = list(review_df.columns[1:5])
-    details = [
-        f"{column}: {clean_cell(selected_row.get(column, '')).strip()}"
-        for column in detail_columns
-    ]
-    st.info(" | ".join(detail for detail in details if not detail.endswith(": ")))
+    visible_details = []
+    for column in display_df.columns:
+        if column in {"Respuesta #", file_column}:
+            continue
+        value = clean_cell(selected_row.get(column, "")).strip()
+        if value:
+            visible_details.append((column, value))
+
+    st.markdown(
+        """
+        <style>
+        .forms-hero {background:linear-gradient(135deg,#fff7ed 0%,#eff6ff 55%,#f5f3ff 100%);border:1px solid #dbeafe;border-radius:20px;padding:18px 20px;margin:12px 0 18px;box-shadow:0 12px 30px rgba(15,23,42,.07);}
+        .forms-hero-title {font-size:1.05rem;font-weight:800;color:#17324d;margin-bottom:4px;}
+        .forms-hero-subtitle {color:#60758a;font-size:.92rem;}
+        .forms-pill {display:inline-block;border-radius:999px;padding:7px 12px;margin:4px 7px 8px 0;font-weight:800;}
+        .forms-pill-id {background:#e0f2fe;color:#075985;}
+        .forms-pill-link {background:#dcfce7;color:#166534;}
+        .forms-pill-missing {background:#fee2e2;color:#991b1b;}
+        .forms-detail {background:linear-gradient(180deg,#ffffff 0%,#fbfdff 100%);border:1px solid #e6edf5;border-left:5px solid #38bdf8;border-radius:14px;padding:12px 14px;margin:7px 0;box-shadow:0 4px 12px rgba(15,23,42,.045);}
+        .forms-label {color:#475569;font-size:0.78rem;font-weight:850;text-transform:uppercase;letter-spacing:.03em;}
+        .forms-value {color:#0f172a;font-size:1rem;margin-top:5px;word-break:break-word;line-height:1.35;}
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+    link_pill_class = "forms-pill-link" if selected_link else "forms-pill-missing"
+    link_pill_text = "✅ Link listo" if selected_link else "⚠️ Sin link detectado"
+    st.markdown(
+        f"<div class='forms-hero'>"
+        f"<div class='forms-hero-title'>📌 Resumen rápido de la respuesta seleccionada</div>"
+        f"<div class='forms-hero-subtitle'>Revisa lo importante de un vistazo y luego manda el link al subtab de envío.</div>"
+        f"<div style='margin-top:10px;'>"
+        f"<span class='forms-pill forms-pill-id'>🧾 Respuesta #{html.escape(str(selected_response))}</span>"
+        f"<span class='forms-pill {link_pill_class}'>{link_pill_text}</span>"
+        f"</div></div>",
+        unsafe_allow_html=True,
+    )
+    if visible_details:
+        cols = st.columns(2)
+        for idx, (column, value) in enumerate(visible_details[:12]):
+            icon = get_forms_field_icon(column)
+            safe_column = html.escape(str(column))
+            safe_value = html.escape(str(value))
+            with cols[idx % 2]:
+                st.markdown(
+                    f"<div class='forms-detail'><div class='forms-label'>{icon} {safe_column}</div>"
+                    f"<div class='forms-value'>{safe_value}</div></div>",
+                    unsafe_allow_html=True,
+                )
+    else:
+        st.info("La respuesta seleccionada no tiene detalles adicionales visibles.")
 
     if selected_link:
-        st.markdown(f"**Link Drive detectado:** {selected_link}")
-        if st.button("📎 Usar este link en el caso seleccionado", disabled=not can_edit):
-            st.session_state["estefano_forms_selected_url"] = selected_link
-            st.success("Link cargado. Revisa el campo 'O pegar link de archivos'.")
-            st.rerun()
+        st.markdown(f"**🔗 Link Drive detectado en Forms:** {selected_link}")
     else:
         st.warning(
             "Esta respuesta no trae link en la columna configurada de archivos STL/DICOM."
         )
 
 
-def render_estefano_tab(current_user: str) -> None:
-    st.subheader("📥 Estefano")
-    can_edit = user_can_edit_tab(current_user, "Estefano")
-    if not can_edit:
-        st.warning("Solo el usuario asignado puede modificar esta pestaña.")
-    with st.expander("📄 Revisar archivos recibidos desde Google Forms", expanded=True):
-        render_estefano_forms_review(can_edit)
+def render_estefano_shipping_tab(current_user: str, can_edit: bool) -> None:
+    """Subtab operativo para enviar documentos y avanzar casos de Estefano."""
+
+    st.markdown("### 📤 Envío de documentos")
     cases_df = filter_estatus_by_status(USER_TAB_STATUSES["Estefano"])
     selected_id, row = render_case_selector(cases_df, "estefano_case_selector")
     if row is None:
@@ -3308,6 +3398,18 @@ def render_estefano_tab(current_user: str) -> None:
             if files_value:
                 update_active_tiempo_row(selected_id, {"ARCHIVOS_ESTEFANO_URL": files_value})
             st.rerun()
+
+
+def render_estefano_tab(current_user: str) -> None:
+    st.subheader("📥 Estefano")
+    can_edit = user_can_edit_tab(current_user, "Estefano")
+    if not can_edit:
+        st.warning("Solo el usuario asignado puede modificar esta pestaña.")
+    shipping_tab, received_tab = st.tabs(["🚚 Envío de documentos", "📋 Recibidos de Forms"])
+    with shipping_tab:
+        render_estefano_shipping_tab(current_user, can_edit)
+    with received_tab:
+        render_estefano_forms_review(can_edit)
 
 def render_jime_tab(current_user: str) -> None:
     st.subheader("🧠 Jime")


### PR DESCRIPTION
### Motivation
- Allow users to select a row in a displayed dataframe and have that selection reflected in the related selectbox to improve UX when working with case lists.
- Make the Google Forms review flow for Estefano more usable and visually scannable by surfacing key fields with icons and a compact hero summary.
- Separate Estefano operations into two subtabs (sending files vs. reviewing received Forms) to clarify responsibilities and reduce UI clutter.

### Description
- Added `apply_single_row_selection_to_selectbox` to synchronize a dataframe single-row selection event with a selectbox via `st.session_state`.
- Updated `render_case_selector` to render the dataframe with `on_select="rerun"`, `selection_mode="single-row"`, a table key, and to call the new synchronization helper, and to set a default `st.session_state` selection when missing.
- Introduced `get_forms_field_icon` to map form field names to emoji icons and added `import html` for safe escaping of values.
- Reworked `render_estefano_forms_review` to paginate/display the most recent 25 responses, use the same single-row table selection sync, show a compact hero with link status, and render visible fields as styled detail cards with icons.
- Split Estefano functionality by adding `render_estefano_shipping_tab` (file upload / send flow) and updating `render_estefano_tab` to present two tabs: `"🚚 Envío de documentos"` and `"📋 Recibidos de Forms"`.
- Minor label tweak to show a status emoji in the case selector labels.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d618a02448326a898f2cee43957e3)