### PR TITLE
Exclude ENVIADO from Jime status filtering

### DIFF
--- a/lab_pg.py
+++ b/lab_pg.py
@@ -292,7 +292,8 @@ STATUS_ALIASES = {
     "EMPACADO/LISTO P/ENVIO": "EMPACADO/LISTO P/ENVÍO",
     "ENVIO DE ENCUESTA": "ENVÍO DE ENCUESTA",
     "LISTO P/ENVÍO": "EMPACADO/LISTO P/ENVÍO",
-    "ENVIADO": "PRODUCTO ENVIADO",
+    # ENVIADO ya no se trata como PRODUCTO ENVIADO: debe quedar fuera de Jime
+    # hasta que el status sea exactamente PRODUCTO ENVIADO para enviar encuesta.
     "ESPERANDO STL PSM": "ESPERANDO STL PSM DOCTOR",
 }
 TERMINAL_STATUSES = {"ENVÍO DE ENCUESTA", "CANCELO"}


### PR DESCRIPTION
### Motivation
- Prevent cases labeled `ENVIADO` from being treated as `PRODUCTO ENVIADO` so the Jime tab and its survey flow only operate when the status is exactly `PRODUCTO ENVIADO`.

### Description
- Removed the `"ENVIADO": "PRODUCTO ENVIADO"` alias from `STATUS_ALIASES` in `lab_pg.py` and added an inline note clarifying the intended behavior.

### Testing
- Ran `git diff --check` and `python3 -m py_compile lab_pg.py`, and both checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e9dfb0e20832695798f4c18b398f7)