### PR TITLE
Rename app lab tabs to workflow-oriented labels

### DIFF
--- a/lab_pg.py
+++ b/lab_pg.py
@@ -130,13 +130,13 @@ USER_TAB_STATUSES = {
 }
 APP_TAB_OPTIONS = {
     "nuevo": "➕ Nuevo pedido",
-    "estefano": "📥 Estefano",
-    "jime": "📋 Jime",
-    "pagos": "💳 Pagos",
-    "lesly": "🖨️ Lesly",
-    "vero": "🛠️ Vero",
+    "estefano": "📐 Planeación y Diseño",
+    "jime": "📋 Recepción y Seguimiento",
+    "pagos": "💳 Control de Pagos",
+    "lesly": "🖨️ Impresión y Sinterizado",
+    "vero": "🛠️ Confección y Calidad",
     "alertas": "⏱️ Alertas",
-    "todos": "📋 Todos",
+    "todos": "📋 Todos los Procesos",
     "procesos": "⚙️ Procesos por Aparato",
 }
 USER_ALLOWED_TRANSITIONS = {


### PR DESCRIPTION
### Motivation
- Hacer que las pestañas de la app describan el área/proceso que representan en vez de usar nombres de usuarios, para una navegación más profesional y comprensible.

### Description
- Cambié las etiquetas en `APP_TAB_OPTIONS` para las claves `estefano`, `jime`, `pagos`, `lesly`, `vero` y `todos` dejando intactas las llaves internas y la lógica de permisos/visibilidad.

### Testing
- Ejecuté `python -m py_compile lab_pg.py` y la verificación de sintaxis pasó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ee3b8f3248326846c7d182e6d42d6)