### PR TITLE
Fix Streamlit date parsing crash

### DIFF
--- a/lab_pg.py
+++ b/lab_pg.py
@@ -652,6 +652,31 @@ def normalize_text(value: Any) -> str:
     return without_accents.upper()
 
 
+def parse_datetime_text(value: Any, *, dayfirst: bool = True) -> pd.Timestamp:
+    """Parsea fechas conocidas evitando warnings de pandas por dayfirst."""
+
+    text = clean_cell(value).strip()
+    if not text:
+        return pd.NaT
+
+    normalized = " ".join(text.replace("/", "-").split())
+    formats = [
+        "%Y-%m-%d %H:%M:%S",
+        "%Y-%m-%d %H:%M",
+        "%Y-%m-%d",
+        "%d-%m-%Y %H:%M:%S",
+        "%d-%m-%Y %H:%M",
+        "%d-%m-%Y",
+    ]
+    for date_format in formats:
+        try:
+            return pd.Timestamp(datetime.strptime(normalized, date_format))
+        except ValueError:
+            continue
+
+    return pd.to_datetime(text, errors="coerce", dayfirst=dayfirst)
+
+
 def parse_simple_date(value: Any) -> date | None:
     """Convierte fechas simples de Sheets a date cuando es seguro hacerlo."""
 
@@ -670,7 +695,7 @@ def parse_simple_date(value: Any) -> date | None:
         except ValueError:
             return None
 
-    parsed = pd.to_datetime(text, errors="coerce", dayfirst=True)
+    parsed = parse_datetime_text(text, dayfirst=True)
     if pd.isna(parsed):
         return None
     return parsed.date()
@@ -710,7 +735,7 @@ def parse_spanish_datetime(value: Any) -> datetime | None:
         except ValueError:
             return None
 
-    parsed = pd.to_datetime(text, errors="coerce", dayfirst=True)
+    parsed = parse_datetime_text(text, dayfirst=True)
     if pd.isna(parsed):
         return None
     return parsed.to_pydatetime().replace(second=0, microsecond=0)
@@ -1580,9 +1605,9 @@ def parse_start_datetime(fecha: Any, hora: Any) -> datetime | None:
         return None
 
     combined = f"{fecha_text} {hora_text}".strip()
-    parsed = pd.to_datetime(combined, errors="coerce", dayfirst=True)
+    parsed = parse_datetime_text(combined, dayfirst=True)
     if pd.isna(parsed):
-        parsed = pd.to_datetime(fecha_text, errors="coerce", dayfirst=True)
+        parsed = parse_datetime_text(fecha_text, dayfirst=True)
     if pd.isna(parsed):
         return None
     return parsed.to_pydatetime()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 streamlit==1.46.0
-pandas==2.3.0
+pandas==2.2.3
 gspread==5.12.2
 google-auth==2.35.0
 google-auth-oauthlib==1.2.1


### PR DESCRIPTION
### Motivation
- Evitar los warnings repetidos de pandas sobre `dayfirst=True` al parsear fechas en Streamlit y prevenir la inestabilidad observada en deploy con `pandas==2.3.0`.

### Description
- Añade `parse_datetime_text(value, *, dayfirst=True)` que intenta formatos comunes (`%Y-%m-%d`, `%Y-%m-%d %H:%M:%S`, `%d-%m-%Y`, etc.) antes de llamar a `pd.to_datetime` como fallback.
- Cambia `parse_simple_date`, `parse_spanish_datetime` y `parse_start_datetime` para usar el parser seguro `parse_datetime_text` y así eliminar el warning localizado en `parse_start_datetime`.
- Actualiza `requirements.txt` para bajar el pin de `pandas` de `2.3.0` a `2.2.3` para evitar la inestabilidad nativa detectada en Streamlit.

### Testing
- Ejecuté `python -m py_compile lab_pg.py` y la compilación fue exitosa.
- Ejecuté un smoke test de parseo de fechas que llamó a `parse_start_datetime`, `parse_simple_date` y `parse_spanish_datetime` capturando warnings y la aserción que no hubiera warnings de "Parsing dates" pasó correctamente.
- Ejecuté `git diff --check` y no se reportaron problemas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a511b20691083269a6e5ec2a036665a)