### PR TITLE
Add robust datetime parsing helper and update dependencies

### DIFF
--- a/lab_pg.py
+++ b/lab_pg.py
@@ -652,6 +652,31 @@ def normalize_text(value: Any) -> str:
     return without_accents.upper()
 
 
+def parse_datetime_text(value: Any, *, dayfirst: bool = True) -> pd.Timestamp:
+    """Parsea fechas conocidas evitando warnings de pandas por dayfirst."""
+
+    text = clean_cell(value).strip()
+    if not text:
+        return pd.NaT
+
+    normalized = " ".join(text.replace("/", "-").split())
+    formats = [
+        "%Y-%m-%d %H:%M:%S",
+        "%Y-%m-%d %H:%M",
+        "%Y-%m-%d",
+        "%d-%m-%Y %H:%M:%S",
+        "%d-%m-%Y %H:%M",
+        "%d-%m-%Y",
+    ]
+    for date_format in formats:
+        try:
+            return pd.Timestamp(datetime.strptime(normalized, date_format))
+        except ValueError:
+            continue
+
+    return pd.to_datetime(text, errors="coerce", dayfirst=dayfirst)
+
+
 def parse_simple_date(value: Any) -> date | None:
     """Convierte fechas simples de Sheets a date cuando es seguro hacerlo."""
 
@@ -670,7 +695,7 @@ def parse_simple_date(value: Any) -> date | None:
         except ValueError:
             return None
 
-    parsed = pd.to_datetime(text, errors="coerce", dayfirst=True)
+    parsed = parse_datetime_text(text, dayfirst=True)
     if pd.isna(parsed):
         return None
     return parsed.date()
@@ -710,7 +735,7 @@ def parse_spanish_datetime(value: Any) -> datetime | None:
         except ValueError:
             return None
 
-    parsed = pd.to_datetime(text, errors="coerce", dayfirst=True)
+    parsed = parse_datetime_text(text, dayfirst=True)
     if pd.isna(parsed):
         return None
     return parsed.to_pydatetime().replace(second=0, microsecond=0)
@@ -1580,9 +1605,9 @@ def parse_start_datetime(fecha: Any, hora: Any) -> datetime | None:
         return None
 
     combined = f"{fecha_text} {hora_text}".strip()
-    parsed = pd.to_datetime(combined, errors="coerce", dayfirst=True)
+    parsed = parse_datetime_text(combined, dayfirst=True)
     if pd.isna(parsed):
-        parsed = pd.to_datetime(fecha_text, errors="coerce", dayfirst=True)
+        parsed = parse_datetime_text(fecha_text, dayfirst=True)
     if pd.isna(parsed):
         return None
     return parsed.to_pydatetime()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,11 @@
 streamlit==1.46.0
-pandas==2.3.0
+pandas==2.2.3
 gspread==5.12.2
 google-auth==2.35.0
 google-auth-oauthlib==1.2.1
 google-auth-httplib2==0.2.0
 openpyxl==3.1.5
 boto3==1.34.162
+numpy==2.0.2
+pyarrow==17.0.0
+protobuf==5.29.5


### PR DESCRIPTION
### Motivation
- Avoid pandas `dayfirst` warnings and improve robustness when parsing various date/time text formats from Sheets. 
- Consolidate parsing logic to handle common formats reliably across several parsing functions. 
- Adjust pinned dependencies to match supported runtime libraries used by parsing and dataframe operations.

### Description
- Added a new helper `parse_datetime_text` that normalizes input, tries a list of explicit `strftime` formats, and falls back to `pd.to_datetime(..., dayfirst=...)` to reduce ambiguous parsing and warnings. 
- Replaced direct `pd.to_datetime(..., dayfirst=True)` calls in `parse_simple_date`, `parse_spanish_datetime`, and `parse_start_datetime` with `parse_datetime_text` to centralize parsing behavior. 
- Updated `requirements.txt` to pin `pandas==2.2.3` and add `numpy==2.0.2`, `pyarrow==17.0.0`, and `protobuf==5.29.5`.

### Testing
- Ran the project test suite with `pytest` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a511b20691083269a6e5ec2a036665a)