### PR TITLE
Mantener feedback y selección en la pestaña Confección y Calidad

### DIFF
--- a/lab_pg.py
+++ b/lab_pg.py
@@ -4535,6 +4535,7 @@ def render_lesly_tab(current_user: str) -> None:
 
 def render_vero_tab(current_user: str) -> None:
     st.subheader("🛠️ Confección y Calidad")
+    render_status_change_feedback()
     can_edit = user_can_edit_tab(current_user, "Vero")
     if not can_edit:
         st.warning("Solo el usuario asignado puede modificar esta pestaña.")
@@ -4543,6 +4544,7 @@ def render_vero_tab(current_user: str) -> None:
     if row is None:
         return
     current_status = normalize_status_alias(get_row_value_by_column(row, STATUS_COLUMN, ""))
+    st.info(f"STATUS actual del pedido seleccionado: {display_selectbox_value(STATUS_COLUMN, current_status)}")
     apparatus = clean_cell(get_row_value_by_column(row, APARATO_COLUMN, ""))
     allowed_targets = [
         status
@@ -4559,6 +4561,7 @@ def render_vero_tab(current_user: str) -> None:
             current_user=current_user,
             comment=comment,
         ):
+            st.session_state["vero_case_selector"] = selected_id
             st.rerun()
     elif not next_status:
         st.info("No hay un siguiente STATUS permitido para Vero en este caso.")


### PR DESCRIPTION
### Motivation
- En la pestaña "Confección y Calidad" el mensaje de confirmación y la selección del pedido se perdían tras el `rerun`, dejando al usuario sin certeza del STATUS actual.
- Es necesario mostrar de forma persistente que el cambio de STATUS se aplicó y mantener la selección para que el flujo operativo sea claro y cómodo.

### Description
- Activa la visualización del mensaje persistente de cambio de STATUS en la pestaña Vero llamando a `render_status_change_feedback()` al inicio de `render_vero_tab`.
- Muestra la línea informativa con el `STATUS` actual del pedido seleccionado usando `st.info(...)` para mayor visibilidad. 
- Conserva explícitamente el pedido seleccionado en `st.session_state["vero_case_selector"] = selected_id` antes de `st.rerun()` tras un cambio exitoso para que la selección no se pierda.

### Testing
- Ejecutado `python -m py_compile lab_pg.py` y la compilación fue exitosa. 
- Ejecutado `git diff --check` y no se encontraron problemas de formato o conflictos en el diff.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a517dd7c51883268ab184cbd649d863)