### PR TITLE
Hide ENVÍO DE ENCUESTA from Jime tab and ignore terminal cases in selector

### DIFF
--- a/lab_pg.py
+++ b/lab_pg.py
@@ -114,7 +114,6 @@ USER_TAB_STATUSES = {
         "GENERACIÓN DE GUÍA",
         "EMPACADO/LISTO P/ENVÍO",
         "PRODUCTO ENVIADO",
-        "ENVÍO DE ENCUESTA",
     ],
     "Pagos": ["PAGO PLANEACIÓN", "PAGO CONFECCIÓN"],
     "Lesly": ["LISTO P/SINTERIZADO", "ELABORACIÓN PLATINA", "EN SINTERIZADO Y HORNEADO"],
@@ -166,6 +165,7 @@ USER_ALLOWED_TRANSITIONS = {
         "GENERACIÓN DE GUÍA": ["EMPACADO/LISTO P/ENVÍO"],
         "EMPACADO/LISTO P/ENVÍO": ["PRODUCTO ENVIADO"],
         "PRODUCTO ENVIADO": ["ENVÍO DE ENCUESTA"],
+        "ENVÍO DE ENCUESTA": [],
     },
     "Pagos": {
         "PAGO PLANEACIÓN": ["EN PLANEACIÓN"],
@@ -3646,7 +3646,7 @@ def get_estatus_row_by_identifier(identifier: str) -> pd.Series | None:
 
 
 def append_recent_selected_case(cases_df: pd.DataFrame, key: str) -> tuple[pd.DataFrame, bool]:
-    """Conserva visible el último pedido seleccionado aunque ya no pertenezca al filtro."""
+    """Conserva visible el último pedido seleccionado si sigue en un STATUS operativo."""
 
     selected_id = clean_cell(st.session_state.get(key, "")).strip()
     if not selected_id or ID_COLUMN not in cases_df.columns:
@@ -3656,6 +3656,10 @@ def append_recent_selected_case(cases_df: pd.DataFrame, key: str) -> tuple[pd.Da
         return cases_df, False
     selected_row = get_estatus_row_by_identifier(selected_id)
     if selected_row is None:
+        return cases_df, False
+    selected_status = normalize_status_alias(get_row_value_by_column(selected_row, STATUS_COLUMN, ""))
+    if selected_status in TERMINAL_STATUSES:
+        st.session_state.pop(key, None)
         return cases_df, False
     return pd.concat([pd.DataFrame([selected_row]), cases_df], ignore_index=True), True
 


### PR DESCRIPTION
### Motivation
- Evitar que los pedidos que ya llegaron a `ENVÍO DE ENCUESTA` sigan apareciendo en la pestaña de Jime (📋 Recepción y Seguimiento) porque ese estatus es terminal.
- Asegurar que un pedido previamente seleccionado no vuelva a reinsertarse en los selectores operativos si ya está en un estatus terminal después de un rerun de Streamlit.

### Description
- Eliminé `"ENVÍO DE ENCUESTA"` de `USER_TAB_STATUSES["Jime"]` en `lab_pg.py` para que no forme parte del filtro de la pestaña Jime.
- Añadí la clave `"ENVÍO DE ENCUESTA": []` en `USER_ALLOWED_TRANSITIONS["Jime"]` para declarar explícitamente que es una transición terminal sin estados siguientes.
- Modifiqué `append_recent_selected_case` en `lab_pg.py` para comprobar el `selected_status` y si está en `TERMINAL_STATUSES` limpiar la selección de sesión y no reinsertar la fila; también actualicé la docstring.

### Testing
- Ejecuté `python -m py_compile lab_pg.py` y la verificación de compilación fue satisfactoria.
- Ejecuté `git diff --check` y no se encontraron errores de diff/whitespace.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51848c945c8326ac6757f8e06ba2ab)